### PR TITLE
Update README to fix the install location for Flatpak Version & Add Instruction for Installation from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,18 @@ A skin to make Steam look more like a native GNOME app
 ```
 git clone https://github.com/tkashkin/Adwaita-for-Steam.git
 cd Adwaita-for-Steam/
-mkdir -p ~/.local/share/Steam/skins
-cp -r ./Adwaita ~/.local/share/Steam/skins
+mkdir -p ~/.local/share/Steam/skins/
+cp -r ./Adwaita ~/.local/share/Steam/skins/
+ln -sf ~/.local/share/Steam/skins ~/.steam/steam/
 ```
 
 ### Linux Flatpak Version
 ```
 git clone https://github.com/tkashkin/Adwaita-for-Steam.git
 cd Adwaita-for-Steam/
-mkdir -p ~/.var/app/com.valvesoftware.Steam/.local/share/Steam/skins
-cp -r ./Adwaita ~/.var/app/com.valvesoftware.Steam/.local/share/Steam/skins
+mkdir -p ~/.var/app/com.valvesoftware.Steam/.local/share/skins/
+cp -rf ./Adwaita ~/.var/app/com.valvesoftware.Steam/.local/share/skins/
+ln -s ~/.var/app/com.valvesoftware.Steam/.local/share/skins ~/.var/app/com.valvesoftware.Steam/.steam/steam/skins
 ```
 
 1. Download the [latest skin version](https://github.com/tkashkin/Adwaita-for-Steam/archive/master.zip)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A skin to make Steam look more like a native GNOME app
 1. Download the [latest skin version](https://github.com/tkashkin/Adwaita-for-Steam/archive/master.zip)
 2. Extract `Adwaita` directory into Steam `skins` directory (create if it doesn't exist):
    * **Linux**: usually `~/.steam/steam/skins` or `~/.local/share/Steam/skins`
-   * **Linux (flatpak)**: `~/.var/app/com.valvesoftware.Steam/.steam/steam/skins`
+   * **Linux (flatpak)**: `~/.var/app/com.valvesoftware.Steam/.local/share/Steam/skins`
    * ~~Windows~~ (untested): `C:\Program Files (x86)\Steam\skins` by default
    * ~~macOS~~ (untested): `~/Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/skins`
 3. Open Steam and select `Adwaita` skin in Settings > Interface (restart Steam if it doesn't appear in the list)

--- a/README.md
+++ b/README.md
@@ -29,10 +29,26 @@ A skin to make Steam look more like a native GNOME app
 
 ## Installation
 
+### Linux Native Version
+```
+git clone https://github.com/tkashkin/Adwaita-for-Steam.git
+cd Adwaita-for-Steam/
+mkdir -p ~/.local/share/Steam/skins
+cp -r ./Adwaita ~/.local/share/Steam/skins
+```
+
+### Linux Flatpak Version
+```
+git clone https://github.com/tkashkin/Adwaita-for-Steam.git
+cd Adwaita-for-Steam/
+mkdir -p ~/.var/app/com.valvesoftware.Steam/.local/share/Steam/skins
+cp -r ./Adwaita ~/.var/app/com.valvesoftware.Steam/.local/share/Steam/skins
+```
+
 1. Download the [latest skin version](https://github.com/tkashkin/Adwaita-for-Steam/archive/master.zip)
 2. Extract `Adwaita` directory into Steam `skins` directory (create if it doesn't exist):
-   * **Linux**: usually `~/.steam/steam/skins` or `~/.local/share/Steam/skins`
-   * **Linux (flatpak)**: `~/.var/app/com.valvesoftware.Steam/.local/share/Steam/skins`
+   * **Linux Native Version**: usually `~/.steam/steam/skins` or `~/.local/share/Steam/skins`
+   * **Linux Flatpak Version**: `~/.var/app/com.valvesoftware.Steam/.local/share/Steam/skins`
    * ~~Windows~~ (untested): `C:\Program Files (x86)\Steam\skins` by default
    * ~~macOS~~ (untested): `~/Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/skins`
 3. Open Steam and select `Adwaita` skin in Settings > Interface (restart Steam if it doesn't appear in the list)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ cp -rf ./Adwaita ~/.var/app/com.valvesoftware.Steam/.local/share/skins/
 ln -s ~/.var/app/com.valvesoftware.Steam/.local/share/skins ~/.var/app/com.valvesoftware.Steam/.steam/steam/skins
 ```
 
+### Manual Installation
 1. Download the [latest skin version](https://github.com/tkashkin/Adwaita-for-Steam/archive/master.zip)
 2. Extract `Adwaita` directory into Steam `skins` directory (create if it doesn't exist):
    * **Linux Native Version**: usually `~/.steam/steam/skins` or `~/.local/share/Steam/skins`


### PR DESCRIPTION
The flatpak version doesn't show the theme. Added Instruction for installation from CLI