### PR TITLE
`windowcontrols/left-all`: match gnome-tweaks' left preset

### DIFF
--- a/patches/windowcontrols/left-all.patch
+++ b/patches/windowcontrols/left-all.patch
@@ -17,7 +17,7 @@
  	layout
  	{
 -		place { control="frame_minimize,frame_maximize,frame_close" align=right spacing=14 margin-right=12 y=12 }
-+		place { control="frame_close,frame_maximize,frame_minimize" spacing=14 margin-left=12 y=12 }
++		place { control="frame_close,frame_minimize,frame_maximize" spacing=14 margin-left=12 y=12 }
  		
  		place { control="frame_title" width=max height=48 }
  		place { control="UINavigatorPanel" width=max height=max }


### PR DESCRIPTION
fixes left-all to be consistent with gnome's left align window controls, which go in the order left to right of "close, minimise, maximise" instead of "close, maximise, minimise".

![image](https://user-images.githubusercontent.com/49787675/189163620-17504af2-9c5c-46b7-8c53-1a14a5531013.png)
