### PR TITLE
Web Full: Window controls patches (Fixes #51)

### DIFF
--- a/install.py
+++ b/install.py
@@ -49,6 +49,11 @@ WEB_FULL_FILES = [
 	webthemedir / "base/10_new_login.css",
 ]
 
+SHARED_PATCHES = [
+	"windowcontrols/hide-close",
+	"windowcontrols/right-all",
+]
+
 def find_patches() -> list[Path]:
 	return list(patchdir.glob("**/*.patch"))
 
@@ -93,13 +98,17 @@ def gen_webkit_theme(target: Path, name: str, selected_extras: list[Path]):
 				shutil.copyfileobj(fd, wfd)
 
 		if selected_extras:
+			print()
 			for f in selected_extras:
-				f = webthemedir / "extras/{}{}".format(f.removesuffix(".css"), ".css")
+				we = f.removesuffix(".css")
+				f = webthemedir / "extras/{}{}".format(we, ".css")
 				if f.exists():
 					with open(f,'rb') as fd:
+						print(f"Applying web_extra {TEXT_BOLD}{we}{TEXT_RESET}...")
 						shutil.copyfileobj(fd, wfd)
 				else:
 					print(f"Web Extra: {TEXT_BOLD}{f}{TEXT_RESET} not found!")
+			print()
 
 def install(source: Path, target: Path, name: str):
 	if target.is_dir():
@@ -144,8 +153,16 @@ if __name__ == "__main__":
 
 		if args.patch:
 			for patch_file in args.patch:
-				patch = patchdir / "{}{}".format(patch_file.removesuffix(".patch"), ".patch")
+				p = patch_file.removesuffix(".patch")
+				patch = patchdir / "{}{}".format(p, ".patch")
+
 				if patch.exists():
+					if [s for s in SHARED_PATCHES if p == s]:
+						if not args.web_extras:
+							args.web_extras = [p]
+						elif not [s for s in args.web_extras if p in s]:
+							args.web_extras.append(p)
+
 					apply_patch(tmp, patch)
 
 		gen_webkit_theme(sourcedir / CSS_FILE, args.web_theme, args.web_extras)

--- a/patches/windowcontrols/hide-close.patch
+++ b/patches/windowcontrols/hide-close.patch
@@ -1,0 +1,11 @@
+# Hide Close Button (Display no Controls)
+--- Adwaita/resource/steamscheme.res
++++ Adwaita/resource/steamscheme.res
+@@ -6,6 +6,7 @@
+ 		{
+ 			frame_close
+ 			{
++				visible 0
+ 				xpos	r31
+ 				ypos	7
+ 				wide	0

--- a/web_themes/extras/windowcontrols/hide-close.css
+++ b/web_themes/extras/windowcontrols/hide-close.css
@@ -1,0 +1,9 @@
+/* --------------------------------- */
+/* --- Hide Window Close Button  --- */
+/* --------------------------------- */
+.title-bar-actions .title-area-icon.closeButton,
+#root [class*="login_CloseButton_"]
+{
+	display: none !important;
+}
+

--- a/web_themes/extras/windowcontrols/right-all.css
+++ b/web_themes/extras/windowcontrols/right-all.css
@@ -1,0 +1,9 @@
+/* ------------------------------------------ */
+/* --- Show Minimize and Maximize Button  --- */
+/* ------------------------------------------ */
+.title-bar-actions .title-area-icon.minimizeButton,
+.title-bar-actions .title-area-icon.maximizeButton
+{
+	display: block !important;
+}
+

--- a/web_themes/full/7_dialogs.css
+++ b/web_themes/full/7_dialogs.css
@@ -190,6 +190,31 @@
 	display: none !important;
 }
 
+.title-area-icon.maximizeButton svg
+{
+	width: 7px !important;
+	margin-left: 9px !important;
+	margin-top: 6px !important;
+}
+
+.title-area-icon.maximizeButton svg rect
+{
+	width: 160px !important;
+	height: 160px !important;
+	stroke-width: 70px !important;
+}
+
+.title-area-icon.maximizeButton svg line
+{
+	display: none !important;
+}
+
+.title-area-icon.minimizeButton svg
+{
+	width: 10px !important;
+	margin-left: 7px !important;
+}
+
 /* PagedSettingsDialog */
 .ModalDialogPopup .DialogContent:not(.GenericConfirmDialog),
 .ModalDialogPopup .DialogContent:not(.GenericConfirmDialog) .DialogContentTransition,


### PR DESCRIPTION
This fixes #51 and partially addresses #56
Window control patches get shared with a corresponding web extra, so you only have to pass:
`-p windowcontrols/hide-close` instead of having to specify both `-p` and `-we` to get the desired effect.

Currently this is limited to `right-all` and `hide-close` as they don't require shifting layout for the web controls. Left style WCs will  likely be another PR.