### PR TITLE
Change playersdialog close button

### DIFF
--- a/Adwaita/resource/layout/playersdialog.layout
+++ b/Adwaita/resource/layout/playersdialog.layout
@@ -2,7 +2,7 @@ playersdialog.layout
 {
 	layout
 	{
-		place { control="frame_close" align=right width=24 height=24 y=12 margin-right=12 }
+		place { control="OKButton" align=right height=34 y=7 margin-right=12 }
 		place { control="frame_title" x=0 y=0 width=max height=48 }
 		place { control="frame_captiongrip" width=max height=48 margin=2 }
 		place { control="sheet" width=max y=3 margin-left=12 margin-right=12 margin-bottom=12 }

--- a/Adwaita/resource/steamscheme.res
+++ b/Adwaita/resource/steamscheme.res
@@ -78,7 +78,7 @@ Scheme
 
 			frame_close
 			{
-				visible	1
+				visible	0
 				xpos	-999
 				ypos	0
 				wide	0
@@ -107,7 +107,7 @@ Scheme
 			
 			CancelButton
 			{
-				xpos	r88
+				xpos	r57
 				ypos	7
 				wide	50
 				tall	34


### PR DESCRIPTION
My previous pull request (#39) caused issue #70, by making frame_close visible for PropertyDialog in steamscheme.res. This pull request hides it again and places the OKButton for playersdialog instead. The OK button in the overlay settingsdialog is moved back to the right.