### PR TITLE
Left window controls fixes

### DIFF
--- a/extras/patches/windowcontrols/left-all.patch
+++ b/extras/patches/windowcontrols/left-all.patch
@@ -133,3 +133,23 @@
  
  		place { control="frame_title" width=max height=48 }
  
+--- Adwaita/steam/cached/SingleUpdateNewsDialog.res
++++ Adwaita/steam/cached/SingleUpdateNewsDialog.res
+@@ -6,11 +6,16 @@
+                {
+                        inset="2 0 2 2"
+                }
++
++               FrameTitle
++               {
++                       padding-left=45
++               }
+        }
+ 
+        layout
+        {
+-               place { control="frame_minimize,frame_close" align=right spacing=14 margin-right=12 y=12 }
++               place { control="frame_close,frame_minimize" align=left spacing=14 margin-left=12 y=12 }
+ 
+                place { control="frame_title" width=max height=48 }
+ 

--- a/extras/patches/windowcontrols/left.patch
+++ b/extras/patches/windowcontrols/left.patch
@@ -118,3 +118,13 @@
  
  		place { control="frame_title" width=max height=48 }
  
+--- Adwaita/steam/cached/SingleUpdateNewsDialog.res
++++ Adwaita/steam/cached/SingleUpdateNewsDialog.res
+@@ -10,7 +10,7 @@
+ 
+        layout
+        {
+-               place { control="frame_minimize,frame_close" align=right spacing=14 margin-right=12 y=12 }
++               place { control="frame_minimize,frame_close" align=left spacing=14 margin-left=12 y=12 }
+ 
+                place { control="frame_title" width=max height=48 }

--- a/extras/web/extras/windowcontrols/left-all.css
+++ b/extras/web/extras/windowcontrols/left-all.css
@@ -36,6 +36,17 @@
 	position: fixed !important;
 }
 
+/* Content Management */
+.TitleBar.title-area
+{
+	z-index: 3 !important;
+}
+
+.ModalDialogPopup [class*="contentmanagement_ContentManagement_"] [class*="boxcarousel_BoxCarouselContents_"]
+{
+	padding-left: 70px;
+}
+
 /* ------------------------------------------ */
 /* --- Show Minimize and Maximize Button  --- */
 /* ------------------------------------------ */

--- a/extras/web/extras/windowcontrols/left-all.css
+++ b/extras/web/extras/windowcontrols/left-all.css
@@ -1,0 +1,47 @@
+/* ------------------------------------- */
+/* --- Left Aligned Window Controls  --- */
+/* ------------------------------------- */
+.title-bar-actions
+{
+	flex-direction: row !important;
+	left: 0px !important;
+	right: auto !important;
+}
+
+/* App Properties Titles */
+.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListColumn_"] > [class*="pagedsettings_PagedSettingsDialog_Title_"]
+{
+	padding-left: 50px !important;
+	padding-right: 50px !important;
+}
+
+/* Friendslist */
+.currentUserContainer .AvatarAndUser
+{
+	padding-left: 125px !important;
+}
+
+.title-bar-actions .title-area-icon.minimizeButton,
+.title-bar-actions .title-area-icon.maximizeButton
+{
+	display: block !important;
+}
+
+.title-bar-actions .title-area-icon.maximizeButton
+{
+	order: 3 !important;
+}
+
+.multiChatDialog .title-bar-actions {
+	position: fixed !important;
+}
+
+/* ------------------------------------------ */
+/* --- Show Minimize and Maximize Button  --- */
+/* ------------------------------------------ */
+.title-bar-actions .title-area-icon.minimizeButton,
+.title-bar-actions .title-area-icon.maximizeButton
+{
+	display: block !important;
+}
+

--- a/extras/web/extras/windowcontrols/left-all.css
+++ b/extras/web/extras/windowcontrols/left-all.css
@@ -37,14 +37,9 @@
 }
 
 /* Content Management */
-.TitleBar.title-area
+[class*="contentmanagement_ContentManagement_"] [class*="contentmanagement_PageableCarousel_"]
 {
-	z-index: 3 !important;
-}
-
-.ModalDialogPopup [class*="contentmanagement_ContentManagement_"] [class*="boxcarousel_BoxCarouselContents_"]
-{
-	padding-left: 70px;
+	margin-left: 70px !important;
 }
 
 /* ------------------------------------------ */

--- a/extras/web/extras/windowcontrols/left.css
+++ b/extras/web/extras/windowcontrols/left.css
@@ -25,12 +25,7 @@
 }
 
 /* Content Management */
-.TitleBar.title-area
+[class*="contentmanagement_ContentManagement_"] [class*="contentmanagement_PageableCarousel_"]
 {
-	z-index: 3 !important;
-}
-
-.ModalDialogPopup [class*="contentmanagement_ContentManagement_"] [class*="boxcarousel_BoxCarouselContents_"]
-{
-	padding-left: 70px;
+	margin-left: 70px !important;
 }

--- a/extras/web/extras/windowcontrols/left.css
+++ b/extras/web/extras/windowcontrols/left.css
@@ -24,3 +24,13 @@
 	position: fixed !important;
 }
 
+/* Content Management */
+.TitleBar.title-area
+{
+	z-index: 3 !important;
+}
+
+.ModalDialogPopup [class*="contentmanagement_ContentManagement_"] [class*="boxcarousel_BoxCarouselContents_"]
+{
+	padding-left: 70px;
+}

--- a/extras/web/extras/windowcontrols/left.css
+++ b/extras/web/extras/windowcontrols/left.css
@@ -1,0 +1,26 @@
+/* ------------------------------------- */
+/* --- Left Aligned Window Controls  --- */
+/* ------------------------------------- */
+.title-bar-actions
+{
+	left: 0px !important;
+	right: auto !important;
+}
+
+/* App Properties Titles */
+.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListColumn_"] > [class*="pagedsettings_PagedSettingsDialog_Title_"]
+{
+	padding-left: 50px !important;
+	padding-right: 50px !important;
+}
+
+/* Friendslist */
+.currentUserContainer .AvatarAndUser
+{
+	padding-left: 50px !important;
+}
+
+.multiChatDialog .title-bar-actions {
+	position: fixed !important;
+}
+

--- a/install.py
+++ b/install.py
@@ -74,6 +74,8 @@ WEB_FULL_FILES = [
 SHARED_PATCHES = [
 	"windowcontrols/hide-close",
 	"windowcontrols/right-all",
+	"windowcontrols/left-all",
+	"windowcontrols/left",
 ]
 
 # List Options

--- a/install.py
+++ b/install.py
@@ -137,7 +137,7 @@ def gen_webkit_theme(target: Path, name: str, selected_extras: list[Path]):
 				we = f.removesuffix(".css")
 				f = Path(f)
 
-				if not f.exists or f.suffix != ".css":
+				if not f.exists() or f.suffix != ".css":
 					f = webthemedir / "extras/{}{}".format(we, ".css")
 
 				if f.exists():


### PR DESCRIPTION
Adds support for left aligned window control patches to affect the web based parts of the interface (#56, #84, #85).
Additionally adds support for the VGUI news dialog to the existing patches (#87)

Currently affects App Properties, Chat, Friend List Settings, and Content Management dialogs. I'm not aware of any other web based dialogs that have window controls.

The `All` patch for web stuff is a bit limited, it only shows controls that exist but were hidden by the default web theme; I can't add controls that don't already exist. 