### PR TITLE
Installer: Patch Steam Library Files (Fixes #113, #119)

### DIFF
--- a/install.py
+++ b/install.py
@@ -233,7 +233,7 @@ def patch_client_css(source: Path, target: Path, name: str):
 	elif name == "Friends":
 		target_css = target / STEAM_FRIENDS_CSS
 		custom_css = target / STEAM_CUSTOM_FRIENDS
-		custom_css_name = STEAM_CUSTOM_FRIENDS.name
+		custom_css_name = custom_css.name
 	else:
 		raise SystemExit(f"{TEXT_RED}{TEXT_CROSS} Invalid steam css patch selected: {name}{TEXT_RESET}")
 

--- a/install.py
+++ b/install.py
@@ -34,6 +34,14 @@ CSS_FILE = "resource/webkit.css"
 TARGET_NORMAL = "~/.steam/steam"
 TARGET_FLATPAK = "~/.var/app/com.valvesoftware.Steam/.steam/steam"
 
+STEAM_LOOPBACK = "https://steamloopback.host"
+STEAM_PATCHED_HEADER = "/*patched*/"
+
+STEAM_FRIENDS_CSS = "clientui/css/friends.css"
+STEAM_LIBRARY_CSS = "steamui/css/library.css"
+STEAM_CUSTOM_LIBRARY = "steamui/libraryroot.custom.css"
+STEAM_CUSTOM_FRIENDS = "clientui/friends.custom.css"
+
 skindir = Path(SKIN_DIR)
 patchdir = Path(PATCH_DIR)
 webthemedir = Path(WEB_THEME_DIR)
@@ -208,6 +216,47 @@ def install(source: Path, target: Path, name: str):
 		shutil.rmtree(target_skin)
 	shutil.copytree(source, target_skin)
 
+def patch_client_css(source: Path, target: Path, name: str):
+	if args.no_steam_patch or args.web_theme == "none":
+		return
+
+	print(f"{TEXT_BLUE}{TEXT_ARROW} Patching Steam Client {TEXT_BOLD}{name}{TEXT_RESET}{TEXT_BLUE} Files...{TEXT_RESET}")
+
+	if not target.is_dir():
+		print(f"{TEXT_PURPLE}{TEXT_INFO} Directory {TEXT_BOLD}{target}{TEXT_RESET}{TEXT_PURPLE} does not exist{TEXT_RESET}")
+		return
+
+	if name == "Library":
+		target_css = target / STEAM_LIBRARY_CSS
+		custom_css = target / STEAM_CUSTOM_LIBRARY
+		custom_css_name = custom_css.name
+	elif name == "Friends":
+		target_css = target / STEAM_FRIENDS_CSS
+		custom_css = target / STEAM_CUSTOM_FRIENDS
+		custom_css_name = STEAM_CUSTOM_FRIENDS.name
+	else:
+		raise SystemExit(f"{TEXT_RED}{TEXT_CROSS} Invalid steam css patch selected: {name}{TEXT_RESET}")
+
+	if not target_css.exists():
+		print(f"{TEXT_PURPLE}{TEXT_INFO} File {TEXT_BOLD}{target_css}{TEXT_RESET}{TEXT_PURPLE} does not exist{TEXT_RESET}")
+		return
+
+	with target_css.open() as css_file:
+		if css_file.readline().strip() == STEAM_PATCHED_HEADER:
+			return
+
+	orig_css = target_css.rename(target_css.with_suffix(".original.css"))
+	name = target_css.stem
+	css_dir = "css"
+	content = f'{STEAM_PATCHED_HEADER}\n@import url("{STEAM_LOOPBACK}/{css_dir}/{name}.original.css");\n@import url("{STEAM_LOOPBACK}/{custom_css_name}");\n'
+	target_css.open('w').write(content)
+
+	size_diff = orig_css.stat().st_size - target_css.stat().st_size
+	padding = "\t" * size_diff
+	target_css.open('a').write(padding)
+
+	shutil.copyfile(source / CSS_FILE, custom_css)
+
 if __name__ == "__main__":
 	if not skindir.exists():
 		raise SystemExit(f"{TEXT_RED}{TEXT_CROSS} Skin directory {TEXT_BOLD}{SKIN_DIR}{TEXT_RESET}{TEXT_RED} does not exist. Make sure you're running the installer from its root directory{TEXT_RESET}")
@@ -222,6 +271,7 @@ if __name__ == "__main__":
 	parser.add_argument("-l", "--list-options", action = "store_true", help = "List available patches, themes, web extras and exit")
 	parser.add_argument("-p", "--patch", nargs = "+", action = "extend", help = "Apply one or multiple patches")
 	parser.add_argument("-n", "--name", default = SKIN_DIR, help = "Rename installed skin")
+	parser.add_argument("-nsp", "--no-steam-patch", action = "store_true", help = "Do not patch steam files")
 	parser.add_argument("-w", "--web-theme", choices = ["base", "full", "none"], default = "base", help = "Choose web theme variant")
 	parser.add_argument("-we", "--web-extras", nargs = "+", action = "extend", help = "Enable one or multiple web theme extras")
 	args = parser.parse_args()
@@ -302,4 +352,6 @@ if __name__ == "__main__":
 
 		for target in targets:
 			install(sourcedir, target, args.name)
+			patch_client_css(sourcedir, target, "Library")
+
 		print(f"{TEXT_GREEN}{TEXT_CHECK} Done!{TEXT_RESET}")


### PR DESCRIPTION
Well it's worse than what we had before, but not much of a choice.
Adds steam patching ala SFP to the installer, which will get the library theming working again.

This does mean a reinstall will have to be performed on client update, unless we want to make the installer have an option to run in the background and watch for file changes. I think the graphical installer would be a better place for something like that though.

This has some bits for chat patching too, but as that still works for the moment I've left it as is.
Moving forward we'd probably want to do something cleaner and have chat/library specific css files rather than the monolithic `webkit.css`, but shrug.