### PR TITLE
Web Extra: Add Library Sidebar Hover

### DIFF
--- a/extras/web/extras/library/sidebar_hover.css
+++ b/extras/web/extras/library/sidebar_hover.css
@@ -1,0 +1,21 @@
+/* -------------------------------------- */
+/* --- Show Library Sidebar on Hover  --- */
+/* -------------------------------------- */
+[class*="library_LeftListSizableContainer_"]:not(:hover)
+{
+	min-width: 6px !important;
+	opacity: 0 !important;
+	transition: width 200ms var(--ease-out-quad) !important;
+	width: 6px !important;
+}
+
+[class*="library_LeftListSizableContainer_"]:hover
+{
+	opacity: 1 !important;
+}
+
+[class*="library_Container_"]
+{
+	background: var(--bg) !important;
+}
+


### PR DESCRIPTION
Adds a web extra to only show the sidebar on hover.
Might add some UX finickiness, but as an optional extra it's probably fine.

Originally wanted to have `:focus-within` also expand the sidebar, but as steam starts with it focused anyway and likes to reset focus back to it when switching views, it wound up too annoying.
Resizing the sidebar can also be a bit pixel perfect when this is active, but shrug.