### PR TITLE
Web Theme: Refine Selectors (Fixes #132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A skin to make Steam look more like a native GNOME app
 * **Main window**: done.
 * **Settings**: mostly done.
 * **New library, new chat, other web-based client parts**: mostly done, with slight [limitations](#limitations).
+* **New Big Picture**: Not done.
 * **Overlay**: done.
 * **Small mode**: done.
 * **Old library, old chat, other old unused windows**: not planned.

--- a/extras/web/README.md
+++ b/extras/web/README.md
@@ -24,7 +24,7 @@ Some classes will be randomly suffixed, eg `library_MainPanel_3BFcm`
 You will need to use the `*=` selector for those:
 
 ```css
-[class*="library_MainPanel_"]
+div[class*="library_MainPanel_"]
 {
 	background: purple !important;
 }

--- a/extras/web/base/collections.css
+++ b/extras/web/base/collections.css
@@ -1,23 +1,23 @@
 /*  --- Collection View --- */
 /* Background */
-[class*="allcollections_ScrollContainer_"],
-[class*="collectionview_OuterContainer_"]
+#SteamDesktop div[class*="allcollections_ScrollContainer_"],
+#SteamDesktop div[class*="collectionview_OuterContainer_"]
 {
 	background: var(--bg) !important;
 }
 
-[class*="allcollections_Collection_"]
+#SteamDesktop div[class*="allcollections_Collection_"]
 {
 	background: var(--button_bg) !important;
 }
 
-[class*="allcollections_Collection_"]:hover
+#SteamDesktop div[class*="allcollections_Collection_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 }
 
 /* Title */
-[class*="allcollections_Label_"]
+#SteamDesktop div[class*="allcollections_Label_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -26,7 +26,7 @@
 }
 
 /* Horiz Rule */
-[class*="allcollections_Rule_"]
+#SteamDesktop div[class*="allcollections_Rule_"]
 {
 	background-color: var(--dim_label_fg) !important;
 	opacity: 0.55 !important;

--- a/extras/web/base/dialogs/launch_options.css
+++ b/extras/web/base/dialogs/launch_options.css
@@ -1,12 +1,12 @@
 /* --- Launch Options --- */
-[class*="launchoptionsdialog_LaunchOptionDialog_"]
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"]
 {
 	background: var(--popover_bg) !important;
 	color: var(--popover_fg) !important;
 	padding: 0 !important;
 }
 
-[class*="launchoptionsdialog_AppNameHeader_"]
+.ModalDialogPopup div[class*="launchoptionsdialog_AppNameHeader_"]
 {
 	box-sizing: border-box !important;
 	height: 48px !important;
@@ -28,12 +28,12 @@
 	text-overflow: ellipsis !important;
 }
 
-[class*="launchoptionsdialog_OptionList_"]
+.ModalDialogPopup div[class*="launchoptionsdialog_OptionList_"]
 {
 	padding: 0 16px 16px 16px !important;
 }
 
-[class*="launchoptionsdialog_ListHeader_"]
+.ModalDialogPopup div[class*="launchoptionsdialog_ListHeader_"]
 {
 	font-family: var(--basefont) !important;
 	font-size: 14px !important;
@@ -45,7 +45,7 @@
 	margin-bottom: 8px !important;
 }
 
-[class*="launchoptionsdialog_ListContainer_"]
+.ModalDialogPopup div[class*="launchoptionsdialog_ListContainer_"]
 {
 	padding: 0 !important;
 	margin: 0 !important;
@@ -55,7 +55,7 @@
 	border-radius: 0 !important;
 }
 
-[class*="launchoptionsdialog_ListItem_"]
+.ModalDialogPopup div[class*="launchoptionsdialog_ListItem_"]
 {
 	background: var(--button_bg) !important;
 	box-sizing: border-box !important;
@@ -68,37 +68,37 @@
 	display: flex !important;
 }
 
-[class*="launchoptionsdialog_ListItem_"]:first-child
+.ModalDialogPopup div[class*="launchoptionsdialog_ListItem_"]:first-child
 {
 	border-top-left-radius: var(--card_radius) !important;
 	border-top-right-radius: var(--card_radius) !important;
 }
 
-[class*="launchoptionsdialog_ListItem_"]:last-child
+.ModalDialogPopup div[class*="launchoptionsdialog_ListItem_"]:last-child
 {
 	border-bottom-left-radius: var(--card_radius) !important;
 	border-bottom-right-radius: var(--card_radius) !important;
 	border-bottom: none !important;
 }
 
-[class*="launchoptionsdialog_ListItem_"]:hover
+.ModalDialogPopup div[class*="launchoptionsdialog_ListItem_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 }
 
-[class*="launchoptionsdialog_ListItem_"]:active
+.ModalDialogPopup div[class*="launchoptionsdialog_ListItem_"]:active
 {
 	background: var(--button_active_bg) !important;
 }
 
-[class*="launchoptionsdialog_ListItem_"] > input
+.ModalDialogPopup div[class*="launchoptionsdialog_ListItem_"] > input
 {
 	width: 16px !important;
 	height: 16px !important;
 	margin: 16px !important;
 }
 
-[class*="launchoptionsdialog_ListItem_"] > label
+.ModalDialogPopup div[class*="launchoptionsdialog_ListItem_"] > label
 {
 	box-sizing: border-box !important;
 	flex-grow: 1 !important;
@@ -115,7 +115,7 @@
 	letter-spacing: normal !important;
 }
 
-[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox
 {
 	background-color: var(--checkbox_bg) !important;
 	box-shadow: var(--checkbox_bs) !important;
@@ -125,18 +125,18 @@
 	margin-top: 3px !important;
 }
 
-[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox:hover
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox:hover
 {
 	box-shadow: var(--checkbox_hover_bs) !important;
 }
 
-[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox:active:not(.Active)
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox:active:not(.Active)
 {
 	box-shadow: none !important;
 	background: var(--checkbox_active_bg) !important;
 }
 
-[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox.Active
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox.Active
 {
 	background: var(--checkbox_checked_bg) !important;
 	background-blend-mode: var(--button_suggested_blend) !important;
@@ -144,34 +144,34 @@
 	box-shadow: none !important;
 }
 
-[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox.Active:hover
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox.Active:hover
 {
 	background-color: var(--button_suggested_hover_bg) !important;
 }
 
-[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox.Active:active
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox.Active:active
 {
 	background-color: var(--button_suggested_click_bg) !important;
 }
 
-[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox svg
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox svg
 {
 	stroke-width: var(--checkbox_checked_sw) !important;
 }
 
-[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox svg path
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox svg path
 {
 	stroke: var(--fg) !important;
 	d: path("M 185 63 L 92 170 l -53 -52") !important;
 	transition: none !important;
 }
 
-[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox_Container
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogCheckbox_Container
 {
 	margin-bottom: 9px !important;
 }
 
-[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogToggle_Label
+.ModalDialogPopup div[class*="launchoptionsdialog_LaunchOptionDialog_"] .DialogToggle_Label
 {
 	padding-top: 4px !important;
 	color: var(--button_fg) !important;
@@ -182,7 +182,7 @@
 	letter-spacing: normal !important;
 }
 
-[class*="launchoptionsdialog_SeeProperties_"]
+.ModalDialogPopup div[class*="launchoptionsdialog_SeeProperties_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -193,14 +193,14 @@
 }
 
 /* Swap buttons to make the Cancel button first */
-[class*="launchoptionsdialog_ButtonContainer_"]
+.ModalDialogPopup div[class*="launchoptionsdialog_ButtonContainer_"]
 {
 	flex-direction: row-reverse !important;
 	overflow: hidden !important;
 	margin: 0 !important;
 }
 
-[class*="launchoptionsdialog_ButtonContainer_"] > *
+.ModalDialogPopup div[class*="launchoptionsdialog_ButtonContainer_"] > *
 {
 	height: 42px !important;
 	line-height: 42px !important;
@@ -223,34 +223,34 @@
 }
 
 
-[class*="launchoptionsdialog_ButtonContainer_"] > *:hover
+.ModalDialogPopup div[class*="launchoptionsdialog_ButtonContainer_"] > *:hover
 {
 	background: rgba(255, 255, 255, 0.07) !important;
 	box-shadow: none !important;
 }
 
-[class*="launchoptionsdialog_ButtonContainer_"] > *:active
+.ModalDialogPopup div[class*="launchoptionsdialog_ButtonContainer_"] > *:active
 {
 	background: rgba(255, 255, 255, 0.16) !important;
 	box-shadow: none !important;
 }
 
-[class*="launchoptionsdialog_ButtonContainer_"] > [class*="launchoptionsdialog_PlayButton_"]
+.ModalDialogPopup div[class*="launchoptionsdialog_ButtonContainer_"] > [class*="launchoptionsdialog_PlayButton_"]
 {
 	color: var(--accent) !important;
 }
 
-[class*="launchoptionsdialog_ButtonContainer_"] > [class*="launchoptionsdialog_PlayButton_"]:hover
+.ModalDialogPopup div[class*="launchoptionsdialog_ButtonContainer_"] > [class*="launchoptionsdialog_PlayButton_"]:hover
 {
 	background: rgba(120, 174, 237, 0.07) !important;
 }
 
-[class*="launchoptionsdialog_ButtonContainer_"] > [class*="launchoptionsdialog_PlayButton_"]:active
+.ModalDialogPopup div[class*="launchoptionsdialog_ButtonContainer_"] > [class*="launchoptionsdialog_PlayButton_"]:active
 {
 	background: rgba(120, 174, 237, 0.16) !important;
 }
 
-[class*="launchoptionsdialog_ListContainer_"] input[type="radio"]
+.ModalDialogPopup div[class*="launchoptionsdialog_ListContainer_"] input[type="radio"]
 {
 	appearance: var(--radio_appearance) !important;
 	border: var(--radio_border) !important;
@@ -259,7 +259,7 @@
 	min-width: var(--radio_min_width) !important;
 }
 
-[class*="launchoptionsdialog_ListContainer_"] input[type="radio"]:checked
+.ModalDialogPopup div[class*="launchoptionsdialog_ListContainer_"] input[type="radio"]:checked
 {
 	appearance: var(--radio_appearance) !important;
 	background: var(--radio_checked_bg) !important;
@@ -269,7 +269,7 @@
 	min-width: var(--radio_min_width) !important;
 }
 
-[class*="launchoptionsdialog_ListContainer_"] input[type="radio"]:focus
+.ModalDialogPopup div[class*="launchoptionsdialog_ListContainer_"] input[type="radio"]:focus
 {
 	outline: none !important;
 }

--- a/extras/web/base/dialogs/login.css
+++ b/extras/web/base/dialogs/login.css
@@ -1,37 +1,37 @@
 /* --- New Login View --- */
 /* BG */
-#root [class*="login_Login_"],
-#root [class*="login_Login_"] [class*="newlogindialog_EmbeddedRoot_"],
-#root [class*="login_Login_"] [class*="newlogindialog_StandardLayout_"][class*="newlogindialog_Embedded_"]
+#root div[class*="login_Login_"].DesktopUI,
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_EmbeddedRoot_"],
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_StandardLayout_"][class*="newlogindialog_Embedded_"]
 {
 	background: var(--bg) !important;
 	overflow: hidden !important;
 	user-select: none !important;
 }
 
-#root [class*="login_Login_"] [class*="login_TitleBar_"]
+#root div[class*="login_Login_"].DesktopUI div[class*="login_TitleBar_"]
 {
 	height: 100px !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_EmbeddedRoot_"]
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_EmbeddedRoot_"]
 {
 	padding: 40px 24px 16px 24px !important;
 }
 
 /* Text */
-#root [class*="login_Login_"] [class*="newlogindialog_Highlight_"]
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_Highlight_"]
 {
 	color: var(--fg) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_FormError_"]
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_FormError_"]
 {
 	color: var(--error) !important;
 }
 
 /* Labels */
-#root [class*="login_Login_"] [class*="newlogindialog_FieldLabel_"]
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_FieldLabel_"]
 {
 	color: var(--dim_label_fg) !important;
 	left: 14px !important;
@@ -46,7 +46,7 @@
 }
 
 /* Entry */
-#root [class*="login_Login_"] [class*="newlogindialog_TextInput_"]
+#root div[class*="login_Login_"].DesktopUI input[class*="newlogindialog_TextInput_"]
 {
 	background: var(--card_bg) !important;
 	border-radius: var(--card_radius) !important;
@@ -60,44 +60,44 @@
 	font-weight: var(--entry_font_weight) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_TextInput_"]:hover
+#root div[class*="login_Login_"].DesktopUI input[class*="newlogindialog_TextInput_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_TextInput_"]:focus
+#root div[class*="login_Login_"].DesktopUI input[class*="newlogindialog_TextInput_"]:focus
 {
 	box-shadow: var(--focusring_bs) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_LoginForm_"]
+#root div[class*="login_Login_"].DesktopUI form[class*="newlogindialog_LoginForm_"]
 {
 	max-width: 480px !important;
 	margin: auto !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_LoginForm_"] [class*="newlogindialog_TextInput_"][type="text"]
+#root div[class*="login_Login_"].DesktopUI form[class*="newlogindialog_LoginForm_"] input[class*="newlogindialog_TextInput_"][type="text"]
 {
 	border-bottom-left-radius: 0px !important;
 	border-bottom-right-radius: 0px !important;
 	margin-bottom: -25px !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_LoginForm_"] [class*="newlogindialog_TextInput_"][type="password"]
+#root div[class*="login_Login_"].DesktopUI form[class*="newlogindialog_LoginForm_"] input[class*="newlogindialog_TextInput_"][type="password"]
 {
 	border-top-right-radius: 0px !important;
 	border-top-left-radius: 0px !important;
 }
 
 /* Remember Me */
-#root [class*="login_Login_"] [class*="newlogindialog_Checkbox_"]:empty
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_Checkbox_"]:empty
 {
 	background: var(--checkbox_bg) !important;
 	border-radius: var(--checkbox_radius) !important;
 	box-shadow: var(--checkbox_bs) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Checkbox_"]
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_Checkbox_"]
 {
 	background: var(--checkbox_checked_bg) !important;
 	background-blend-mode: var(--button_suggested_blend) !important;
@@ -105,33 +105,33 @@
 	box-shadow: none !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Checkbox_"]:hover
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_Checkbox_"]:hover
 {
 	background-color: var(--button_suggested_hover_bg) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Checkbox_"]:empty:active
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_Checkbox_"]:empty:active
 {
 	background: var(--button_hover_bg) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Checkbox_"]:active
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_Checkbox_"]:active
 {
 	background-color: var(--button_suggested_click_bg) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Checkbox_"] [class*="newlogindialog_Check_"] svg
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_Checkbox_"] div[class*="newlogindialog_Check_"] svg
 {
 	stroke-width: var(--checkbox_checked_sw) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Checkbox_"]:focus
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_Checkbox_"]:focus
 {
 	outline: none !important;
 }
 
 /* Submit Button */
-#root [class*="login_Login_"] [class*="newlogindialog_SubmitButton_"]
+#root div[class*="login_Login_"].DesktopUI button[class*="newlogindialog_SubmitButton_"]
 {
 	background-blend-mode: var(--button_suggested_blend) !important;
 	background: var(--button_suggested_bg) !important;
@@ -146,60 +146,61 @@
 	font-weight: 700 !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_SubmitButton_"]:hover
+#root div[class*="login_Login_"].DesktopUI button[class*="newlogindialog_SubmitButton_"]:hover
 {
 	background-color: var(--button_suggested_hover_bg) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_SubmitButton_"]:active
+#root div[class*="login_Login_"].DesktopUI button[class*="newlogindialog_SubmitButton_"]:active
 {
 	background-color: var(--button_suggested_click_bg) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_SubmitButton_"]:focus
+#root div[class*="login_Login_"].DesktopUI button[class*="newlogindialog_SubmitButton_"]:focus
 {
 	outline: none !important;
 }
 
-#root [class*="login_Login_"]
+#root div[class*="login_Login_"].DesktopUI
 {
 	height: 100% !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Login_"]
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_Login_"]
 {
 	display: flex !important;
 	height: 100% !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_BetaContainer_"],
-#root [class*="login_Login_"] [class*="newlogindialog_LoginForm_"]
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_BetaContainer_"],
+#root div[class*="login_Login_"].DesktopUI form[class*="newlogindialog_LoginForm_"]
 {
 	align-items: stretch !important;
 	align-content: center !important;
 	align-self: center !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_EmbeddedRoot_"]
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_EmbeddedRoot_"]
 {
 	column-gap: 16px !important;
 	row-gap: 0 !important;
 	flex-grow: 1 !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_JoinBetaButton_"]
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_JoinBetaButton_"]
 {
 	text-decoration: none !important;
 	border-radius: var(--button_pill_radius) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_HeaderLogo_"]
+#root div[class*="login_Login_"].DesktopUI svg[class*="newlogindialog_HeaderLogo_"]
 {
 	margin: auto !important;
 }
 
 /* Steam Guard dialog */
-#root [class*="login_Login_"] [class*="newlogindialog_Compact_"]
+/* TODO */
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_Compact_"]
 {
 	width: 100% !important;
 	padding: 24px !important;
@@ -213,8 +214,8 @@
 	text-transform: none !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Compact_"] [class*="newlogindialog_PrimaryHeader_"],
-#root [class*="login_Login_"] [class*="newlogindialog_Compact_"] [class*="newlogindialog_FailureTitle_"]
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_Compact_"] [class*="newlogindialog_PrimaryHeader_"],
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_Compact_"] [class*="newlogindialog_FailureTitle_"]
 {
 	color: var(--popover_fg) !important;
 	font-family: var(--basefont) !important;
@@ -226,33 +227,33 @@
 	text-align: center;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Compact_"] [class*="newlogindialog_SegmentedCharacterInput_"]
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_Compact_"] [class*="newlogindialog_SegmentedCharacterInput_"]
 {
 	background: var(--entry_bg) !important;
 	border-radius: var(--entry_radius) !important;
 	transition: var(--focus_transition) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Compact_"] [class*="newlogindialog_SegmentedCharacterInput_"]:focus-within
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_Compact_"] [class*="newlogindialog_SegmentedCharacterInput_"]:focus-within
 {
 	box-shadow: var(--focusring_bs) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Compact_"] [class*="newlogindialog_SegmentedCharacterInput_"] input
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_Compact_"] [class*="newlogindialog_SegmentedCharacterInput_"] input
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_Compact_"] [class*="newlogindialog_FormContainer_"]
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_Compact_"] [class*="newlogindialog_FormContainer_"]
 {
 	padding: 0 !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_CheckboxField_"] [class*="newlogindialog_CheckboxFieldLabel_"],
-#root [class*="login_Login_"] [class*="newlogindialog_TextLink_"],
-#root [class*="login_Login_"] [class*="newlogindialog_UseMobileAppForQR_"],
-#root [class*="login_Login_"] [class*="newlogindialog_EmbeddedRootFooter_"]
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_CheckboxField_"] div[class*="newlogindialog_CheckboxFieldLabel_"],
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_TextLink_"],
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_UseMobileAppForQR_"],
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_EmbeddedRootFooter_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -260,13 +261,13 @@
 	font-weight: 400 !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_TextLink_"]
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_TextLink_"]
 {
 	font-weight: 700 !important;
 	text-decoration: none !important;
 }
 
-#root [class*="login_Login_"] [class*="newlogindialog_TextLink_"]:hover
+#root div[class*="login_Login_"].DesktopUI [class*="newlogindialog_TextLink_"]:hover
 {
 	text-decoration: underline !important;
 }

--- a/extras/web/base/dialogs/login.css
+++ b/extras/web/base/dialogs/login.css
@@ -2,7 +2,8 @@
 /* BG */
 #root div[class*="login_Login_"].DesktopUI,
 #root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_EmbeddedRoot_"],
-#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_StandardLayout_"][class*="newlogindialog_Embedded_"]
+#root div[class*="login_Login_"].DesktopUI div[class*="newlogindialog_StandardLayout_"][class*="newlogindialog_Embedded_"],
+#root > div[class*="index_PreloadThrobber_"]
 {
 	background: var(--bg) !important;
 	overflow: hidden !important;

--- a/extras/web/base/downloads.css
+++ b/extras/web/base/downloads.css
@@ -1,18 +1,18 @@
 /* --- Downloads View --- */
 /* BG */
-[class*="downloads_DownloadsPage_"]
+#SteamDesktop div[class*="downloads_DownloadsPage_"]
 {
 	background: var(--bg) !important;
 }
 
 /* - Header - */
-[class*="downloadgraph_GraphAndStats_"]
+#SteamDesktop div[class*="downloadgraph_GraphAndStats_"]
 {
 	background: var(--view_bg) !important;
 	border-bottom: 1px solid var(--border) !important;
 }
 
-[class*="downloadgraph_StatsPanel_"] [class*="downloadgraph_Figure_"]
+#SteamDesktop div[class*="downloadgraph_StatsPanel_"] div[class*="downloadgraph_Figure_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -20,8 +20,8 @@
 	font-weight: var(--title_4_weight) !important;
 }
 
-[class*="downloadgraph_StatsPanel_"] [class*="downloadgraph_Label_"],
-[class*="downloadgraph_DownloadGraphLegend_"] [class*="downloadgraph_LegendText_"]
+#SteamDesktop div[class*="downloadgraph_StatsPanel_"] div[class*="downloadgraph_Label_"],
+#SteamDesktop div[class*="downloadgraph_DownloadGraphLegend_"] div[class*="downloadgraph_LegendText_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -30,53 +30,53 @@
 }
 
 /* Remove Gradient when Downloads are Empty */
-[class*="downloadgraph_HeroAndLogo_"],
-[class*="downloadgraph_HeroAndLogo_"] img[class*="libraryassetimage_Visible_"]
+#SteamDesktop div[class*="downloadgraph_HeroAndLogo_"],
+#SteamDesktop div[class*="downloadgraph_HeroAndLogo_"] img[class*="libraryassetimage_Visible_"]
 {
 	background: none !important;
 }
 
 /* Blue Separator Line */
-[class*="downloads_TopBar_SEmVp"]
+#SteamDesktop div[class*="downloads_TopBar_"]
 {
 	background: none !important;
 }
 
 /* Top Right Settings Button */
-[class*="downloadgraph_SettingsButton_"] button
+#SteamDesktop div[class*="downloadgraph_SettingsButton_"] button
 {
 	background: var(--button_bg) !important;
 }
 
-[class*="downloadgraph_SettingsButton_"] button:hover
+#SteamDesktop div[class*="downloadgraph_SettingsButton_"] button:hover
 {
 	background: var(--button_hover_bg) !important;
 }
 
-[class*="downloadgraph_SettingsButton_"] button.DialogButton:enabled
+#SteamDesktop div[class*="downloadgraph_SettingsButton_"] button.DialogButton:enabled
 {
 	color: var(--button_fg) !important;
 }
 
 /* Graph Colors */
-[class*="downloadgraph_DownloadGraph_"] [class*="downloadgraph_GraphBarDownload_"],
-[class*="downloadgraph_DownloadGraphLegend_"] [class*="downloadgraph_Network_"] svg
+#SteamDesktop div[class*="downloadgraph_DownloadGraph_"] rect[class*="downloadgraph_GraphBarDownload_"],
+#SteamDesktop div[class*="downloadgraph_DownloadGraphLegend_"] div[class*="downloadgraph_Network_"] svg
 {
 	color: var(--accent_bg) !important;
 }
 
-[class*="downloadgraph_DownloadGraph_"] [class*="downloadgraph_GraphLine_"]
+#SteamDesktop div[class*="downloadgraph_DownloadGraph_"] path[class*="downloadgraph_GraphLine_"]
 {
 	stroke: var(--success_bg) !important;
 }
 
-[class*="downloadgraph_DownloadGraphLegend_"] [class*="downloadgraph_Disk_"]
+#SteamDesktop div[class*="downloadgraph_DownloadGraphLegend_"] div[class*="downloadgraph_Disk_"]
 {
 	background: var(--success_bg) !important;
 }
 
 /* - Downloads - */
-[class*="downloads_Title_"]
+#SteamDesktop span[class*="downloads_Title_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -84,7 +84,7 @@
 	font-weight: var(--title_3_weight) !important;
 }
 
-[class*="downloads_EmptyTransfers_"] [class*="downloads_Text_"]
+#SteamDesktop div[class*="downloads_EmptyTransfers_"] div[class*="downloads_Text_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -92,7 +92,7 @@
 	font-weight: var(--title_4_weight) !important;
 }
 
-[class*="downloads_SectionTitle_"] [class*="downloads_Count_"]
+#SteamDesktop div[class*="downloads_SectionTitle_"] span[class*="downloads_Count_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -100,13 +100,13 @@
 	font-weight: var(--title_3_weight) !important;
 }
 
-[class*="downloads_SectionTitle_"] [class*="downloads_Rule_"]
+#SteamDesktop div[class*="downloads_SectionTitle_"] div[class*="downloads_Rule_"]
 {
 	background-color: var(--dim_label_fg) !important;
 	opacity: 0.55 !important;
 }
 
-[class*="downloads_AutoUpdateHours_"]
+#SteamDesktop div[class*="downloads_AutoUpdateHours_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -115,17 +115,17 @@
 }
 
 /* Download Items */
-[class*="downloads_SectionItem_"]
+#SteamDesktop div[class*="downloads_SectionItem_"]
 {
 	background: var(--card_bg) !important;
 }
 
-[class*="downloads_SectionItem_"]:hover
+#SteamDesktop div[class*="downloads_SectionItem_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 }
 
-[class*="downloads_SectionItem_"] [class*="downloads_Name_"]
+#SteamDesktop div[class*="downloads_SectionItem_"] span[class*="downloads_Name_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -133,7 +133,7 @@
 	font-weight: var(--title_3_weight) !important;
 }
 
-[class*="downloads_ProgressDetails_"] [class*="downloads_Value_"]
+#SteamDesktop div[class*="downloads_ProgressDetails_"] span[class*="downloads_Value_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -141,7 +141,7 @@
 	font-weight: var(--title_4_weight) !important;
 }
 
-[class*="downloads_ProgressDetails_"] [class*="downloads_Value_"][class*="downloads_InProgress_"]
+#SteamDesktop div[class*="downloads_ProgressDetails_"] span[class*="downloads_Value_"][class*="downloads_InProgress_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -149,22 +149,22 @@
 	font-weight: var(--title_4_weight) !important;
 }
 
-[class*="downloads_ContentTypes_"]
+#SteamDesktop div[class*="downloads_ContentTypes_"]
 {
 	color: var(--fg) !important;
 }
 
-[class*="downloads_Active_"] [class*="downloads_SectionList_"]
+#SteamDesktop div[class*="downloads_Active_"] div[class*="downloads_SectionList_"]
 {
 	border: none !important;
 }
 
-[class*="downloads_SectionList_"] [class*="downloads_SectionItemWrapper_"]
+#SteamDesktop div[class*="downloads_SectionList_"] div[class*="downloads_SectionItemWrapper_"]
 {
 	padding: var(--menu_margin) 0px !important;
 }
 
-[classs*="downloads_SectionItemStatus_"]
+#SteamDesktop div[classs*="downloads_SectionItemStatus_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -172,7 +172,7 @@
 	font-weight: var(--title_3_weight) !important;
 }
 
-[class*="downloads_SectionItemStatus_"] [class*="downloads_InProgress_"]
+#SteamDesktop div[class*="downloads_SectionItemStatus_"] span[class*="downloads_InProgress_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -180,7 +180,7 @@
 	font-weight: var(--title_4_weight) !important;
 }
 
-[class*="downloads_SectionItemStatus_"] [class*="downloads_Progress_"]
+#SteamDesktop div[class*="downloads_SectionItemStatus_"] span[class*="downloads_Progress_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -188,13 +188,13 @@
 	font-weight: var(--title_4_weight) !important;
 }
 
-[class*="downloads_SectionItemStatus_"] [class*="downloads_ProgressBar_"]
+#SteamDesktop div[class*="downloads_SectionItemStatus_"] div[class*="downloads_ProgressBar_"]
 {
 	background: var(--button_bg) !important;
 }
 
 /* Buttons */
-[class*="downloads_Button_"]
+#SteamDesktop button[class*="downloads_Button_"]
 {
 	background: none !important;
 	color: var(--button_fg) !important;
@@ -203,7 +203,7 @@
 	font-weight: var(--button_font_weight) !important;
 }
 
-[class*="downloads_RemoveAllButton_"]
+#SteamDesktop button[class*="downloads_RemoveAllButton_"]
 {
 	background: var(--button_bg) !important;
 	font-family: var(--basefont) !important;
@@ -211,13 +211,13 @@
 	font-weight: var(--button_font_weight) !important;
 }
 
-[class*="downloads_RemoveAllButton_"].DialogButton:enabled
+#SteamDesktop button[class*="downloads_RemoveAllButton_"].DialogButton:enabled
 {
 	color: var(--button_fg) !important;
 }
 
-[class*="downloads_Button_"]:hover,
-[class*="downloads_RemoveAllButton_"]:hover
+#SteamDesktop button[class*="downloads_Button_"]:hover,
+#SteamDesktop button[class*="downloads_RemoveAllButton_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	border: none !important;

--- a/extras/web/base/game_details.css
+++ b/extras/web/base/game_details.css
@@ -1,24 +1,24 @@
 /* --- Game Details View --- */
 /* Background */
-[class*="appdetails_Glassy_"]
+#SteamDesktop div[class*="appdetails_Glassy_"]
 {
 	background: var(--bg) !important;
 }
 
 /*  Disable Blurred Background */
-[class*="sharedappdetailsheader_ImgBlurBackdrop_"]
+#SteamDesktop img[class*="sharedappdetailsheader_ImgBlurBackdrop_"]
 {
 	display: none !important;
 }
 
 /* `Scroll to Top` Button */
-[class*="smartscrollcontainer_ScrollToTopButton_"]
+#SteamDesktop div[class*="smartscrollcontainer_ScrollToTopButton_"]
 {
 	color: var(--toast_fg) !important;
 	height: 50px !important;
 }
 
-[class*="smartscrollcontainer_ScrollToTopButton_"] div
+#SteamDesktop div[class*="smartscrollcontainer_ScrollToTopButton_"] > div
 {
 	background: var(--toast_bg) !important;
 	border-radius: var(--toast_border_radius) !important;
@@ -30,19 +30,19 @@
 }
 
 /* Play Button Color */
-[class*="appactionbutton_ButtonChild"]
+#SteamDesktop div[class*="appactionbutton_ButtonChild"]
 {
 	background: var(--accent_bg) !important;
 }
 
-[class*="appactionbutton_Green"] > [class*="appactionbutton_ButtonChild"]
+#SteamDesktop div[class*="appactionbutton_Green"] > div[class*="appactionbutton_ButtonChild"]
 {
 	background: var(--success_bg) !important;
 }
 
 /* Progress Bar Color */
-[class*="appdetailsplaysection_DetailsProgressBar_"],
-[class*="appdetailsachievementssection_AchievementProgress_"]
+#SteamDesktop div[class*="appdetailsplaysection_DetailsProgressBar_"],
+#SteamDesktop div[class*="appdetailsachievementssection_AchievementProgress_"]
 {
 	background: var(--accent_bg) !important;
 }

--- a/extras/web/base/library.css
+++ b/extras/web/base/library.css
@@ -3,7 +3,7 @@
 /* --------------- */
 
 /* Post Login Loading Screen */
-[class*="index_Container_"][class*="index_PreloadThrobber_"]
+#SteamDesktop div[class*="index_Container_"][class*="index_PreloadThrobber_"]
 {
 	background: var(--bg) !important;
 }
@@ -16,35 +16,35 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 
 /* --- Main Library View --- */
 /* Backgrounds */
-#root > [class*="library_Container_"],
-[class*="libraryhome_LibraryHome_"],
-[class*="library_AppDetailsTransitionGroup_"]
+#SteamDesktop div[class*="library_Container_"],
+#SteamDesktop div[class*="libraryhome_LibraryHome_"],
+#SteamDesktop div[class*="library_AppDetailsTransitionGroup_"]
 {
 	background: var(--bg) !important;
 	box-shadow: none !important;
 }
 
-[class*="libraryhome_UpdatesContainer_"]
+#SteamDesktop div[class*="libraryhome_UpdatesContainer_"]
 {
 	background: var(--view_bg) !important;
 	border-bottom: 1px solid var(--border) !important;
 }
 
-[class*="libraryhome_Container_"]
+#SteamDesktop div[class*="libraryhome_Container_"]
 {
 	background: none !important;
 }
 
 /* Mouse Over Descriptions */
-[class*="appdetailsgameinfopanel_Description_"]
+#SteamDesktop div[class*="appdetailsgameinfopanel_Description_"]
 {
 	background: var(--popover_bg) !important;
 }
 
 /* Showcase Headers */
-[class*="libraryhomeshowcases_CollectionDropDown_"] ._DialogInputContainer,
-[class*="libraryhomeshowcases_CountDisplay_"],
-[class*="libraryhome_UpdatesContainer_"] [class*="pageablecontainer_Name_"]
+#SteamDesktop div[class*="libraryhomeshowcases_CollectionDropDown_"] ._DialogInputContainer,
+#SteamDesktop div[class*="libraryhomeshowcases_CountDisplay_"],
+#SteamDesktop div[class*="libraryhome_UpdatesContainer_"] div[class*="pageablecontainer_Name_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -52,7 +52,7 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 	font-size: var(--title_2_size) !important;
 }
 
-[class*="appgrid_SortingDropDownLabel_"]
+#SteamDesktop div[class*="appgrid_SortingDropDownLabel_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -60,24 +60,24 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 	font-size: var(--title_3_size) !important;
 }
 
-[class*="appgrid_SortingDropDown_"] > ._DialogInputContainer
+#SteamDesktop div[class*="appgrid_SortingDropDown_"] > ._DialogInputContainer
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
 	font-weight: var(--baseweight) !important;
 }
 
-[class*="appgrid_SortingDropDown_"] > ._DialogInputContainer .DialogDropDown_Arrow svg
+#SteamDesktop div[class*="appgrid_SortingDropDown_"] > ._DialogInputContainer .DialogDropDown_Arrow svg
 {
 	fill: var(--fg) !important;
 }
 
-[class*="libraryhomenewupdates_SettingsButton_"] svg path
+#SteamDesktop div[class*="libraryhomenewupdates_SettingsButton_"] svg path
 {
 	fill: var(--dim_label_fg) !important;
 }
 
-[class*="libraryhomerecentgames_AddedDate_"]
+#SteamDesktop div[class*="libraryhomerecentgames_AddedDate_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -85,11 +85,11 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 }
 
 /* Popup Elements */
-[class*="libraryhomeshowcases_CollectionDropDownContainer_"][class*="libraryhomeshowcases_CollectionDropDownContainer_"] ._DialogInputContainer[class*="dropdown_DialogDropDownMenu_"],
-.DialogMenuPosition[class*="appgrid_SortingDropDownContainer_"] > div,
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div[class*="libraryhomeshowcases_CollectionDropDownContainer_"][class*="libraryhomeshowcases_CollectionDropDownContainer_"] ._DialogInputContainer[class*="dropdown_DialogDropDownMenu_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > .DialogMenuPosition[class*="appgrid_SortingDropDownContainer_"] > div,
 [class*="tooltip_TextToolTip_"],
-[class*="contextmenu_contextMenu_"],
-[class*="contextmenu_ContextMenuFocusContainer_"] [class*="dropdown_DialogDropDownMenu_Item_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div[class*="contextmenu_contextMenu_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div[class*="contextmenu_ContextMenuFocusContainer_"] div[class*="dropdown_DialogDropDownMenu_Item_"]
 {
 	background: var(--popover_bg) !important;
 	border: none !important;
@@ -99,61 +99,60 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 	font-weight: var(--baseweight) !important;
 }
 
-[class*="contextmenu_ContextMenuFocusContainer_"] [class*="dropdown_DialogDropDownMenu_Item_"]:hover,
-[class*="contextmenu_contextMenuItem_"]:hover,
-[class*="contextmenu_contextMenuItem_"][class*="contextmenu_active_"],
-[class*="library_ContextMenuAction_"]:hover
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div[class*="contextmenu_ContextMenuFocusContainer_"] div[class*="dropdown_DialogDropDownMenu_Item_"]:hover,
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div[class*="contextmenu_contextMenu_"] div[class*="contextmenu_contextMenuItem_"]:hover,
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div[class*="contextmenu_contextMenu_"] div[class*="contextmenu_contextMenuItem_"][class*="contextmenu_active_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div[class*="contextmenu_contextMenu_"] div[class*="library_ContextMenuAction_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	border-radius: var(--menu_radius) !important;
 }
 
-[class*="library_ContextMenuAction_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div[class*="contextmenu_contextMenu_"] [class*="library_ContextMenuAction_"]
 {
 	background: none !important;
 	border-radius: var(--menu_radius) !important;
 }
 
 /* Play Button */
-[class*="appportrait_Play_1"]
+#SteamDesktop div[class*="appportrait_Play_1"]
 {
 	background: var(--success_bg) !important;
 }
 
-[class*="appportrait_Download_"]
+#SteamDesktop div[class*="appportrait_Download_"]
 {
 	background: var(--accent_bg) !important;
 }
 
 /* Update Summary */
-[class*="libraryhomenewupdates_HoversEnabled_"]:hover [class*="libraryhomenewupdates_EventSummaryContainer_"]
+#SteamDesktop div[class*="libraryhomenewupdates_HoversEnabled_"]:hover div[class*="libraryhomenewupdates_EventSummaryContainer_"]
 {
 	background: var(--toast_bg) !important;
 }
 
-[class*="libraryhomenewupdates_EventOptions_"] > div
+#SteamDesktop div[class*="libraryhomenewupdates_EventOptions_"] > div
 {
 	background-color: var(--button_bg) !important;
 }
 
-[class*="libraryhomenewupdates_EventOptions_"]:hover > div
+#SteamDesktop div[class*="libraryhomenewupdates_EventOptions_"]:hover > div
 {
 	background-color: var(--button_hover_bg) !important;
 }
 
 /* --- Left Panel --- */
 /* Backgrounds */
-[class*="gamelistbar_Container_"],
-[class*="gamelistbar_GameListHomeAndSearch_"],
-[class*="gamelistsectionheader_Container_"],
-[class*="gamelisthome_Bar_"]
+#SteamDesktop div[class*="gamelistbar_Container_"],
+#SteamDesktop div[class*="gamelistbar_GameListHomeAndSearch_"],
+#SteamDesktop div[class*="gamelistsectionheader_Container_"]
 {
 	background: var(--bg) !important;
 	box-shadow: none !important;
 }
 
 /* Separator */
-[class*="library_LibraryWindowDivider_"]
+#SteamDesktop div[class*="library_LibraryWindowDivider_"]
 {
 	background: rgba(255, 255, 255, 0.2) !important;
 	min-width: 1px !important;
@@ -161,19 +160,20 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 }
 
 /* Home and Collections */
-[class*="gamelisthome_Bar_"]
+#SteamDesktop a[class*="gamelisthome_Bar_"]
 {
 	background: var(--button_bg) !important;
 	border-radius: var(--button_radius) !important;
+	box-shadow: none !important;
 }
 
-[class*="gamelisthome_Bar_"]:hover
+#SteamDesktop a[class*="gamelisthome_Bar_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	border-radius: var(--button_radius) !important;
 }
 
-[class*="gamelisthome_Label_"]
+#SteamDesktop div[class*="gamelisthome_Label_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -181,27 +181,27 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 	font-weight: var(--button_font_weight) !important;
 }
 
-[class*="gamelisthome_CollectionIconBox_"]
+#SteamDesktop div[class*="gamelisthome_CollectionIconBox_"]
 {
 	background: var(--button_fg) !important;
 	opacity: 0.2 !important;
 }
 
-[class*="gamelisthome_CollectionButton_"]:hover [class*="gamelisthome_CollectionIconBox_"]
+#SteamDesktop a[class*="gamelisthome_CollectionButton_"]:hover div[class*="gamelisthome_CollectionIconBox_"]
 {
 	opacity: 0.8 !important;
 }
 
 /* Filters and Buttons */
-[class*="gamelistdropdown_Bar_"]
+#SteamDesktop div[class*="gamelistdropdown_Bar_"]
 {
 	padding: 0px 6px !important;
 }
 
-[class*="gamelistdropdown_MenuHeader_"],
-[class*="gamelistdropdown_ScrollToTop_"] .SVGIcon_Arrow,
-[class*="appfilterpane_SaveButton_"],
-[class*="gamelistsearchbar_FilterTag_"]
+#SteamDesktop div[class*="gamelistdropdown_MenuHeader_"],
+#SteamDesktop div[class*="gamelistdropdown_ScrollToTop_"] .SVGIcon_Arrow,
+#SteamDesktop button[class*="appfilterpane_SaveButton_"],
+#SteamDesktop div[class*="gamelistsearchbar_FilterTag_"]
 {
 	background: var(--button_bg) !important;
 	border: none !important;
@@ -212,54 +212,54 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 	font-weight: var(--button_font_weight) !important;
 }
 
-[class*="gamelistdropdown_MenuHeader_"]:hover,
-[class*="gamelistdropdown_ScrollToTop_"]:hover .SVGIcon_Arrow
+#SteamDesktop div[class*="gamelistdropdown_MenuHeader_"]:hover,
+#SteamDesktop div[class*="gamelistdropdown_ScrollToTop_"]:hover .SVGIcon_Arrow
 {
 	background: var(--button_hover_bg) !important;
 	border: none !important;
 	border-radius: var(--button_radius) !important;
 }
 
-[class*="gamelistdropdown_Active_"] svg
+#SteamDesktop div[class*="gamelistdropdown_Active_"] svg
 {
 	fill: var(--accent_bg) !important;
 }
 
-[class*="gamelistdropdown_Active_"] svg circle
+#SteamDesktop div[class*="gamelistdropdown_Active_"] svg circle
 {
 	stroke: var(--accent_bg) !important;
 }
 
-[class*="gamelistdropdown_DropDown_"],
-[class*="appfilterpane_Container_"],
-[class*="appfilterpane_Description_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div[class*="gamelistdropdown_DropDown_"],
+#SteamDesktop div[class*="appfilterpane_Container_"],
+#SteamDesktop [class*="appfilterpane_Description_"]
 {
 	background: var(--popover_bg) !important;
 }
 
-[class*="appfilterpane_FilterBucketLabel_"]
+#SteamDesktop div[class*="appfilterpane_FilterBucketLabel_"]
 {
 	color: var(--fg) !important;
 }
 
-[class*="appfilterpane_SaveButton_"].Disabled
+#SteamDesktop button[class*="appfilterpane_SaveButton_"].Disabled
 {
 	background: var(--button_disabled_bg) !important;
 	color: var(--button_disabled_fg) !important;
 }
 
-[class*="gamelistsearchbar_AdvancedSearchPane_Woh0k"]::before
+#SteamDesktop div[class*="gamelistsearchbar_AdvancedSearchPane_"]::before
 {
 	background: none !important;
 }
 
 /* Game Search */
-[class*="gamelistsearchbar_SearchInput_"] input
+#SteamDesktop div[class*="gamelistsearchbar_SearchInput_"] input
 {
 	background-color: transparent !important;
 }
 
-[class*="gamelistsearchbar_SearchInput_"]
+#SteamDesktop div[class*="gamelistsearchbar_SearchInput_"]
 {
 	background-color: var(--button_bg) !important;
 	border-radius: var(--button_radius) !important;
@@ -268,7 +268,7 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 	color: var(--fg) !important;
 }
 
-[class*="gamelistsearchbar_SearchInput_"]:hover
+#SteamDesktop div[class*="gamelistsearchbar_SearchInput_"]:hover
 {
 	background-color: var(--button_hover_bg) !important;
 	border-radius: var(--button_radius) !important;
@@ -276,12 +276,12 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 	border-bottom-right-radius: 0px !important;
 }
 
-[class*="gamelistsearchbar_SearchInput_"] input:focus
+#SteamDesktop div[class*="gamelistsearchbar_SearchInput_"] input:focus
 {
 	box-shadow: none !important;
 }
 
-[class*="gamelistsearchbar_AdvancedSearchButton_"]
+#SteamDesktop div[class*="gamelistsearchbar_AdvancedSearchButton_"]
 {
 	background: var(--button_bg) !important;
 	border-radius: var(--button_radius) !important;
@@ -289,13 +289,13 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 	border-bottom-left-radius: 0px !important;
 }
 
-[class*="gamelistsearchbar_AdvancedSearchContainer_"]
+#SteamDesktop div[class*="gamelistsearchbar_AdvancedSearchContainer_"]
 {
 	background: none !important;
 }
 
-[class*="gamelistsearchbar_AdvancedSearchContainer_"]:hover,
-[class*="gamelistsearchbar_AdvancedSearchContainer_"][class*="gamelistsearchbar_Extended_"]
+#SteamDesktop div[class*="gamelistsearchbar_AdvancedSearchContainer_"]:hover,
+#SteamDesktop div[class*="gamelistsearchbar_AdvancedSearchContainer_"][class*="gamelistsearchbar_Extended_"]
 {
 	background: var(--button_hover_bg) !important;
 	border-radius: var(--button_radius) !important;
@@ -304,140 +304,140 @@ html[class*="gamepadui_SteamUIPopupHTML_"]
 }
 
 /* Game Headers and Rows */
-[class*="gamelistsectionheader_SectionName"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) span[class*="gamelistsectionheader_SectionName"]
 {
 	color: var(--fg) !important;
 	font-weight: var(--title_3_weight) !important;
 	font-family: var(--basefont) !important;
 }
 
-[class*="gamelistsectionheader_Container_"],
-[class*="gamelistentry_Container_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistsectionheader_Container_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Container_"]
 {
 	border: none !important;
 	margin-left: 6px !important;
 }
 
-[class*="gamelistentry_GameListEntryContainer_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_GameListEntryContainer_"]
 {
 	border: none !important;
 	padding-left: 6px !important;
 }
 
-[class*="gamelistentry_Installed_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Installed_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
 	font-weight: var(--baseweight) !important;
 }
 
-[class*="gamelistentry_Uninstalled_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Uninstalled_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
 	font-weight: var(--baseweight) !important;
 }
 
-[class*="gamelist_Container_"] .ReactVirtualized__Grid[style*="overflow: hidden;"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelist_Container_"] .ReactVirtualized__Grid[style*="overflow: hidden;"]
 {
 	/* Only try to pad if the list doesnt overflow */
 	padding-right: 6px !important;
 }
 
-[class*="gamelistentry_GameIcon_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_GameIcon_"]
 {
 	margin: 0px 6px 0px 0px !important;
 }
 
-[class*="gamelistentry_Container_"]:hover,
-[class*="gamelistsectionheader_Container_"]:hover
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Container_"]:hover,
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistsectionheader_Container_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	border-radius: var(--menu_radius) !important;
 }
 
-[class*="gamelistentry_Selected_"][class*="gamelistentry_Container_"],
-[class*="gamelistentry_Selected_"][class*="gamelistentry_Container_"] :hover,
-[class*="gamelistentry_Selected_"] > [class*="gamelistentry_Container_"],
-[class*="gamelistentry_Selected_"] > [class*="gamelistentry_Container_"]:hover,
-[class*="gamelistentry_Selected_"] > [class*="gamelistentry_Container_"] :hover
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Selected_"][class*="gamelistentry_Container_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Selected_"][class*="gamelistentry_Container_"] :hover,
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Selected_"] > [class*="gamelistentry_Container_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Selected_"] > [class*="gamelistentry_Container_"]:hover,
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Selected_"] > [class*="gamelistentry_Container_"] :hover
 {
 	background: none !important;
 	box-shadow: none !important;
 }
 
-[class*="gamelistsectionheader_Selected_"],
-[class*="gamelistentry_HasContextMenuOpen_"],
-[class*="gamelistentry_Selected_"] [class*="gamelistentry_GameListEntryContainer_"],
-[class*="gamelistentry_Selected_"] [class*="gamelistentry_GameListEntryContainer_"][class*="gamelistentry_CloudError_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistsectionheader_Selected_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_HasContextMenuOpen_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Selected_"] div[class*="gamelistentry_GameListEntryContainer_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Selected_"] div[class*="gamelistentry_GameListEntryContainer_"][class*="gamelistentry_CloudError_"]
 {
 	background: var(--button_bg) !important;
 	border-radius: var(--button_radius) !important;
 }
 
-[class*="gamelistentry_HasContextMenuOpen_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_HasContextMenuOpen_"]
 {
 	border: 1px var(--focusring) solid !important;
 }
 
-[class*="gamelistentry_HasContextMenuOpen_"] [class*="gamelistentry_GameListEntryContainer_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_HasContextMenuOpen_"] div[class*="gamelistentry_GameListEntryContainer_"]
 {
 	margin-left: -1px !important;
 }
 
-[class*="gamelistsectionheader_Selected_"]:hover,
-[class*="gamelistentry_Selected_"] [class*="gamelistentry_GameListEntryContainer_"]:hover,
-[class*="gamelistentry_Selected_"] [class*="gamelistentry_GameListEntryContainer_"][class*="gamelistentry_CloudError_"]:hover
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistsectionheader_Selected_"]:hover,
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Selected_"] div[class*="gamelistentry_GameListEntryContainer_"]:hover,
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Selected_"] div[class*="gamelistentry_GameListEntryContainer_"][class*="gamelistentry_CloudError_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	border-radius: var(--button_radius) !important;
 }
 
-[class*="gamelistentry_Updating_"],
-[class*="gamelistentry_DownloadProgress_"],
-[class*="gamelistentry_Synchronizing_"],
-[class*="gamelistentry_CloudError_"],
-[class*="gamelistentry_CloudOutOfDate_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Updating_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_DownloadProgress_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Synchronizing_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_CloudError_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_CloudOutOfDate_"]
 {
 	color: var(--accent) !important;
 }
 
-[class*="gamelistentry_Running_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="gamelistentry_Running_"]
 {
 	color: var(--success) !important;
 }
 
-[class*="gamelistentry_HoverOverlay_"],
-[class*="gamelistentry_HoverOverlay_"][class*="gamelistentry_Selected_"],
-[class*="gamelistentry_Selected_"] [class*="gamelistentry_Container_"][class*="gamelistentry_HoverOverlay_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div > div[class*="hoverposition_HoverPosition_"] div[class*="gamelistentry_HoverOverlay_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div > div[class*="hoverposition_HoverPosition_"] div[class*="gamelistentry_HoverOverlay_"][class*="gamelistentry_Selected_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div > div[class*="hoverposition_HoverPosition_"] div[class*="gamelistentry_Selected_"] [class*="gamelistentry_Container_"][class*="gamelistentry_HoverOverlay_"]
 {
 	background: var(--bg) !important;
 	border-radius: var(--menu_radius) !important;
 }
 
-[class*="gamelistentry_HoverOverlay_"] [class*="gamelistentry_GameListEntryContainer_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) > div > div[class*="hoverposition_HoverPosition_"] div[class*="gamelistentry_HoverOverlay_"] [class*="gamelistentry_GameListEntryContainer_"]
 {
 	background: var(--button_hover_bg) !important;
 }
 
 /* Drag & Drop */
-[class*="gamelistentry_Container_"][class*="gamelistentry_DropTarget_"] {
+#SteamDesktop div[class*="gamelistentry_Container_"][class*="gamelistentry_DropTarget_"] {
 	background-color: var(--button_bg) !important;
 	border-left: 1px solid var(--accent_bg) !important;
 	border-right: 1px solid var(--accent_bg) !important;
 }
 
-[class*="gamelistsectionheader_Container_"][class*="gamelistsectionheader_DropOption_"] {
+#SteamDesktop div[class*="gamelistsectionheader_Container_"][class*="gamelistsectionheader_DropOption_"] {
 	background-color: var(--button_bg) !important;
 }
 
-[class*="gamelistsectionheader_Container_"][class*="gamelistsectionheader_DropTarget_"] {
+#SteamDesktop div[class*="gamelistsectionheader_Container_"][class*="gamelistsectionheader_DropTarget_"] {
 	border-left: 1px solid var(--accent_bg) !important;
 	border-right: 1px solid var(--accent_bg) !important;
 	border-top: 1px solid var(--accent_bg) !important;
 }
 
-[class*="gamelistentry_Container_"][class*="gamelistentry_DropTarget_"][class*="gamelistentry_LastInCollection_"],
-[class*="gamelistsectionheader_Container_"][class*="gamelistsectionheader_DropTarget_"][class*="gamelistsectionheader_SingleLine_"] {
+#SteamDesktop div[class*="gamelistentry_Container_"][class*="gamelistentry_DropTarget_"][class*="gamelistentry_LastInCollection_"],
+#SteamDesktop div[class*="gamelistsectionheader_Container_"][class*="gamelistsectionheader_DropTarget_"][class*="gamelistsectionheader_SingleLine_"] {
 	border-bottom: 1px solid var(--accent_bg) !important;
 }

--- a/extras/web/full/dialogs/_dialogs.css
+++ b/extras/web/full/dialogs/_dialogs.css
@@ -30,7 +30,7 @@
 .GenericConfirmDialog .DialogBodyText[class*="cloudconflict_CloudConflictWarning_"],
 .GenericConfirmDialog [class*="cloudconflict_FooterNote_"],
 .GenericConfirmDialog [class*="cloudconflict_ChoiceNote_"],
-.GenericConfirmDialog [class*="moveappsdialog_MoveAppsDialog_"] > .DialogBody
+.GenericConfirmDialog div[class*="moveappsdialog_MoveAppsDialog_"] > .DialogBody
 {
 	color: var(--popover_fg) !important;
 	font-family: var(--basefont) !important;
@@ -129,7 +129,7 @@
 	padding: 0 !important;
 }
 
-.GenericConfirmDialog [class*="moveappsdialog_MoveAppsDialog_"] > .DialogBody .DialogInputLabelGroup
+.GenericConfirmDialog div[class*="moveappsdialog_MoveAppsDialog_"] > .DialogBody .DialogInputLabelGroup
 {
 	margin-top: 24px !important;
 	margin-bottom: 0 !important;
@@ -334,13 +334,13 @@
 	top: 40% !important;
 }
 
-.ModalDialogPopup [class*="dropdown_DialogDropDownMenu_"]
+.ModalDialogPopup div[class*="dropdown_DialogDropDownMenu_"]
 {
 	background: var(--popover_bg) !important;
 	border-radius: var(--popover_radius) !important;
 }
 
-.ModalDialogPopup [class*="dropdownlabel_DropDownLabelTitle_"]
+.ModalDialogPopup div[class*="dropdownlabel_DropDownLabelTitle_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -349,7 +349,7 @@
 
 }
 
-.ModalDialogPopup [class*="dropdownlabel_DropDownLabelDescription_"]
+.ModalDialogPopup div[class*="dropdownlabel_DropDownLabelDescription_"]
 {
 	color: var(--entry_subtitle_fg) !important;
 	font-family: var(--basefont) !important;
@@ -368,8 +368,8 @@
 }
 
 /* Checkboxes */
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_Install_"] > .DialogCheckbox,
-.ModalDialogPopup [class*="contentmanagement_AppSelected_"] > .DialogCheckbox
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_Install_"] > .DialogCheckbox,
+.ModalDialogPopup div[class*="contentmanagement_AppSelected_"] > .DialogCheckbox
 {
 	background-color: var(--checkbox_bg) !important;
 	box-shadow: var(--checkbox_bs) !important;
@@ -378,21 +378,21 @@
 	width: 20px !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_Install_"] > .DialogCheckbox:hover,
-.ModalDialogPopup [class*="contentmanagement_AppSelected_"] > .DialogCheckbox:hover
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_Install_"] > .DialogCheckbox:hover,
+.ModalDialogPopup div[class*="contentmanagement_AppSelected_"] > .DialogCheckbox:hover
 {
 	box-shadow: var(--checkbox_hover_bs) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_Install_"] > .DialogCheckbox:active:not(.Active),
-.ModalDialogPopup [class*="contentmanagement_AppSelected_"] > .DialogCheckbox:active:not(.Active)
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_Install_"] > .DialogCheckbox:active:not(.Active),
+.ModalDialogPopup div[class*="contentmanagement_AppSelected_"] > .DialogCheckbox:active:not(.Active)
 {
 	box-shadow: none !important;
 	background: var(--checkbox_active_bg) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_Install_"] > .DialogCheckbox.Active,
-.ModalDialogPopup [class*="contentmanagement_AppSelected_"] > .DialogCheckbox.Active
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_Install_"] > .DialogCheckbox.Active,
+.ModalDialogPopup div[class*="contentmanagement_AppSelected_"] > .DialogCheckbox.Active
 {
 	background: var(--checkbox_checked_bg) !important;
 	background-blend-mode: var(--button_suggested_blend) !important;
@@ -400,26 +400,26 @@
 	box-shadow: none !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_Install_"] > .DialogCheckbox.Active:hover,
-.ModalDialogPopup [class*="contentmanagement_AppSelected_"] > .DialogCheckbox.Active:hover
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_Install_"] > .DialogCheckbox.Active:hover,
+.ModalDialogPopup div[class*="contentmanagement_AppSelected_"] > .DialogCheckbox.Active:hover
 {
 	background-color: var(--button_suggested_hover_bg) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_Install_"] > .DialogCheckbox.Active:active,
-.ModalDialogPopup [class*="contentmanagement_AppSelected_"] > .DialogCheckbox.Active:active
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_Install_"] > .DialogCheckbox.Active:active,
+.ModalDialogPopup div[class*="contentmanagement_AppSelected_"] > .DialogCheckbox.Active:active
 {
 	background-color: var(--button_suggested_click_bg) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_Install_"] > .DialogCheckbox svg,
-.ModalDialogPopup [class*="contentmanagement_AppSelected_"] > .DialogCheckbox svg
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_Install_"] > .DialogCheckbox svg,
+.ModalDialogPopup div[class*="contentmanagement_AppSelected_"] > .DialogCheckbox svg
 {
 	stroke-width: var(--checkbox_checked_sw) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_Install_"] > .DialogCheckbox svg path,
-.ModalDialogPopup [class*="contentmanagement_AppSelected_"] > .DialogCheckbox svg path
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_Install_"] > .DialogCheckbox svg path,
+.ModalDialogPopup div[class*="contentmanagement_AppSelected_"] > .DialogCheckbox svg path
 {
 	stroke: var(--fg) !important;
 	d: path("M 185 63 L 92 170 l -53 -52") !important;
@@ -427,7 +427,7 @@
 }
 
 /* Checkboxes as Switches */
-.ModalDialogPopup [class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox,
 .FriendsSettingsNotificationRow_Checkbox .DialogCheckbox
 {
 	background: var(--card_bg) !important;
@@ -439,25 +439,25 @@
 	min-width: 44px !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox.Active,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox.Active,
 .FriendsSettingsNotificationRow_Checkbox .DialogCheckbox.Active
 {
 	background: var(--button_suggested_bg) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox:hover,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox:hover,
 .FriendsSettingsNotificationRow_Checkbox .DialogCheckbox:hover
 {
 	background-color: var(--button_suggested_hover_bg) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox:active,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox:active,
 .FriendsSettingsNotificationRow_Checkbox .DialogCheckbox:active
 {
 	background-color: var(--button_suggested_click_bg) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox .SVGIcon_DialogCheck,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox .SVGIcon_DialogCheck,
 .FriendsSettingsNotificationRow_Checkbox .DialogCheckbox .SVGIcon_DialogCheck
 {
 	opacity: 1 !important;
@@ -465,13 +465,13 @@
 	margin-left: -2px !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox.Active .SVGIcon_DialogCheck,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox.Active .SVGIcon_DialogCheck,
 .FriendsSettingsNotificationRow_Checkbox .DialogCheckbox.Active .SVGIcon_DialogCheck
 {
 	margin-left: 20px !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox svg path,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div:not([class*="appproperties_Install_"]) > .DialogCheckbox svg path,
 .FriendsSettingsNotificationRow_Checkbox .DialogCheckbox svg path
 {
 	d: path("M 100, 100 m -75, 0 a 160,160 0 1,0 320,0 a 160,160 0 1,0 -320,0") !important;
@@ -481,18 +481,18 @@
 }
 
 /* Toggle Switch */
-.ModalDialogPopup [class*="toggle_Toggle_"]
+.ModalDialogPopup div[class*="toggle_Toggle_"]
 {
 	display: flex;
 	align-items: center;
 }
 
-.ModalDialogPopup [class*="toggle_ToggleSwitch_"]
+.ModalDialogPopup div[class*="toggle_ToggleSwitch_"]
 {
 	background: var(--fg) !important;
 }
 
-.ModalDialogPopup [class*="toggle_ToggleRail_"]
+.ModalDialogPopup div[class*="toggle_ToggleRail_"]
 {
 	background: var(--entry_bg) !important;
 	background-blend-mode: var(--button_suggested_blend) !important;
@@ -504,27 +504,27 @@
 	width: 48px !important;
 }
 
-.ModalDialogPopup [class*="toggle_ToggleRail_"]:hover
+.ModalDialogPopup div[class*="toggle_ToggleRail_"]:hover
 {
 	background-color: var(--button_suggested_hover_bg) !important;
 }
 
-.ModalDialogPopup [class*="toggle_ToggleRail_"]:active
+.ModalDialogPopup div[class*="toggle_ToggleRail_"]:active
 {
 	background-color: var(--button_suggested_click_bg) !important;
 }
 
-.ModalDialogPopup [class*="toggle_Highlight_"]
+.ModalDialogPopup div[class*="toggle_Highlight_"]
 {
 	background: var(--button_suggested_bg) !important;
 }
 
-.ModalDialogPopup [class*="toggle_Highlight_"][class*="toggle_Off_"]
+.ModalDialogPopup div[class*="toggle_Highlight_"][class*="toggle_Off_"]
 {
 	display: none !important;
 }
 
-.ModalDialogPopup [class*="toggle_ToggleSwitch_"]
+.ModalDialogPopup div[class*="toggle_ToggleSwitch_"]
 {
 	border-radius: var(--button_pill_radius) !important;
 	height: 22.5px !important;
@@ -535,7 +535,7 @@
 	width: 22.5px !important;
 }
 
-.ModalDialogPopup [class*="toggle_ToggleSwitch_"][class*="toggle_Off_"]
+.ModalDialogPopup div[class*="toggle_ToggleSwitch_"][class*="toggle_Off_"]
 {
 	margin-left: 1px !important;
 }

--- a/extras/web/full/dialogs/app_properties.css
+++ b/extras/web/full/dialogs/app_properties.css
@@ -1,19 +1,19 @@
 /* --- App Properties --- */
 /* Top Gap */
-.ModalDialogPopup [class*="appproperties_TopGap_"]
+.ModalDialogPopup div[class*="appproperties_TopGap_"]
 {
 	margin-top: 1px !important;
 }
 
 /* Headings */
-.ModalDialogPopup [class*="appproperties_Title_"]
+.ModalDialogPopup div[class*="appproperties_Title_"]
 {
 	font-family: var(--basefont) !important;
 	font-size: var(--header_size) !important;
 	font-weight: var(--header_weight) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_Detail_"]
+.ModalDialogPopup div[class*="appproperties_Detail_"]
 {
 	font-family: var(--basefont) !important;
 	font-size: var(--label_size) !important;
@@ -21,20 +21,20 @@
 }
 
 /* Top Border */
-.ModalDialogPopup [class*="appproperties_SectionTopLine_"]
+.ModalDialogPopup div[class*="appproperties_SectionTopLine_"]
 {
 	border-top: none !important;
 }
 
 /* Blue Highlighted Text */
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_BlueHighlight_"]
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] span[class*="appproperties_BlueHighlight_"]
 {
 	color: var(--fg) !important;
 	font-weight: 500 !important;
 }
 
 /* Controller List */
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_SteamInputStatusGrid_"]
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_SteamInputStatusGrid_"]
 {
 	background: var(--card_bg) !important;
 	border-radius: var(--card_radius) !important;
@@ -61,20 +61,20 @@
 }
 
 /* DLC & Workshop Grid */
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_DlcGrid_"],
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_WorkshopGrid_"]
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_DlcGrid_"],
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_WorkshopGrid_"]
 {
 	border-radius: var(--card_radius) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_DlcGrid_"] [class*="appproperties_DlcHeader_"],
-.ModalDialogPopup [class*="appproperties_AppProperties_"] [class*="appproperties_WorkshopGrid_"] [class*="appproperties_WorkshopHeader_"]
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_DlcGrid_"] div[class*="appproperties_DlcHeader_"],
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] div[class*="appproperties_WorkshopGrid_"] div[class*="appproperties_WorkshopHeader_"]
 {
 	background: var(--card_solid_bg) !important;
 }
 
 /* Checkboxes as Switches */
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogCheckbox_Container
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogCheckbox_Container
 {
 	align-items: center !important;
 	background: var(--entry_bg) !important;
@@ -85,36 +85,36 @@
 	transition: var(--focus_transition) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogCheckbox_Container:hover
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogCheckbox_Container:hover
 {
 	background: var(--button_hover_bg) !important;
 	box-shadow: none !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogCheckbox_Container:active
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogCheckbox_Container:active
 {
 	background: var(--button_active_bg) !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogControlsSection .DialogCheckbox_Container:not(:last-child):first-child,
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogBody .DialogCheckbox_Container:not(:last-child):first-child,
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogBody .DialogDropDown:not(:last-child):first-child
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogControlsSection .DialogCheckbox_Container:not(:last-child):first-child,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogBody .DialogCheckbox_Container:not(:last-child):first-child,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogBody .DialogDropDown:not(:last-child):first-child
 {
 	border-bottom-right-radius: 0px !important;
 	border-bottom-left-radius: 0px !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogControlsSection .DialogCheckbox_Container:not(:first-child):last-child,
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogBody .DialogCheckbox_Container:not(:first-child):last-child,
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogBody .DialogDropDown:not(:first-child):last-child,
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogBody .DialogCheckbox_Container + .DialogInputLabelGroup > .DialogDropDown,
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogBody .DialogInputLabelGroup > .DialogDropDown + .DialogCheckbox_Container
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogControlsSection .DialogCheckbox_Container:not(:first-child):last-child,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogBody .DialogCheckbox_Container:not(:first-child):last-child,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogBody .DialogDropDown:not(:first-child):last-child,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogBody .DialogCheckbox_Container + .DialogInputLabelGroup > .DialogDropDown,
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogBody .DialogInputLabelGroup > .DialogDropDown + .DialogCheckbox_Container
 {
 	border-top-right-radius: 0px !important;
 	border-top-left-radius: 0px !important;
 }
 
-.ModalDialogPopup [class*="appproperties_AppProperties_"] .DialogBody .DialogInputLabelGroup > .DialogLabel + .DialogDropDown
+.ModalDialogPopup div[class*="appproperties_AppProperties_"] .DialogBody .DialogInputLabelGroup > .DialogLabel + .DialogDropDown
 {
 	border-top-right-radius: var(--entry_radius) !important;
 	border-top-left-radius: var(--entry_radius) !important;

--- a/extras/web/full/dialogs/content_management.css
+++ b/extras/web/full/dialogs/content_management.css
@@ -1,5 +1,5 @@
 /* --- Content Management */
-.DialogBody[class*="contentmanagement_ContentManagement_"]
+.ModalDialogPopup .DialogBody[class*="contentmanagement_ContentManagement_"]
 {
 	background: var(--window_bg) !important;
 	color: var(--window_fg) !important;
@@ -9,12 +9,12 @@
 	letter-spacing: normal !important;
 }
 
-[class*="contentmanagement_ContentManagement_"] [class*="contentmanagement_Header_"]
+.ModalDialogPopup .DialogBody[class*="contentmanagement_ContentManagement_"] div[class*="contentmanagement_Header_"]
 {
 	padding: 0 !important;
 }
 
-[class*="contentmanagement_ContentManagement_"] [class*="contentmanagement_Title_"]
+.ModalDialogPopup .DialogBody[class*="contentmanagement_ContentManagement_"] div[class*="contentmanagement_Title_"]
 {
 	box-sizing: border-box !important;
 	height: 48px !important;
@@ -38,7 +38,7 @@
 	border-bottom: 1px var(--headerbar_shade) solid !important;
 }
 
-[class*="contentmanagement_ContentManagement_"] [class*="contentmanagement_PageableCarousel_"]
+.ModalDialogPopup .DialogBody[class*="contentmanagement_ContentManagement_"] div[class*="contentmanagement_PageableCarousel_"]
 {
 	height: 34px !important;
 	margin: -41px 48px 7px 7px !important;
@@ -49,13 +49,13 @@
 	align-items: center !important;
 }
 
-:focus-within [class*="contentmanagement_ContentManagement_"] [class*="contentmanagement_Title_"],
-:focus-within [class*="contentmanagement_ContentManagement_"] [class*="contentmanagement_PageableCarousel_"]
+.ModalDialogPopup:focus-within .DialogBody[class*="contentmanagement_ContentManagement_"] div[class*="contentmanagement_Title_"],
+.ModalDialogPopup:focus-within .DialogBody[class*="contentmanagement_ContentManagement_"] div[class*="contentmanagement_PageableCarousel_"]
 {
 	background: var(--headerbar_bg) !important;
 }
 
-[class*="contentmanagement_InstallFolder_"]
+.ModalDialogPopup div[class*="contentmanagement_InstallFolder_"]
 {
 	padding: 0 8px !important;
 	margin-right: 4px !important;
@@ -70,7 +70,7 @@
 	overflow: hidden !important;
 }
 
-[class*="contentmanagement_InstallFolder_"] > svg
+.ModalDialogPopup div[class*="contentmanagement_InstallFolder_"] > svg
 {
 	width: 16px !important;
 	height: 16px !important;
@@ -78,33 +78,33 @@
 	color: var(--button_disabled_fg) !important;
 }
 
-:focus-within [class*="contentmanagement_InstallFolder_"],
-:focus-within [class*="contentmanagement_InstallFolder_"] > svg
+.ModalDialogPopup:focus-within div[class*="contentmanagement_InstallFolder_"],
+.ModalDialogPopup:focus-within div[class*="contentmanagement_InstallFolder_"] > svg
 {
 	color: var(--button_fg) !important;
 }
 
-[class*="contentmanagement_InstallFolder_"][class*="contentmanagement_IsSelected_"]
+.ModalDialogPopup div[class*="contentmanagement_InstallFolder_"][class*="contentmanagement_IsSelected_"]
 {
 	background: var(--button_bg) !important;
 	box-shadow: none !important;
 }
 
-[class*="contentmanagement_InstallFolder_"]:hover
+.ModalDialogPopup div[class*="contentmanagement_InstallFolder_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	box-shadow: none !important;
 }
 
-[class*="contentmanagement_InstallFolder_"]:active
+.ModalDialogPopup div[class*="contentmanagement_InstallFolder_"]:active
 {
 	background: var(--button_active_bg) !important;
 	box-shadow: none !important;
 }
 
-[class*="contentmanagement_InstallFolder_"] [class*="contentmanagement_FolderInfo_"],
-[class*="contentmanagement_InstallFolder_"] [class*="contentmanagement_FolderInfo_"] [class*="contentmanagement_DriveName_"],
-[class*="contentmanagement_InstallFolder_"] [class*="contentmanagement_FolderInfo_"] [class*="contentmanagement_DriveSize_"]
+.ModalDialogPopup div[class*="contentmanagement_InstallFolder_"] div[class*="contentmanagement_FolderInfo_"],
+.ModalDialogPopup div[class*="contentmanagement_InstallFolder_"] div[class*="contentmanagement_FolderInfo_"] div[class*="contentmanagement_DriveName_"],
+.ModalDialogPopup div[class*="contentmanagement_InstallFolder_"] div[class*="contentmanagement_FolderInfo_"] div[class*="contentmanagement_DriveSize_"]
 {
 	color: inherit !important;
 	text-transform: none !important;
@@ -113,20 +113,20 @@
 	text-overflow: ellipsis !important;
 }
 
-[class*="contentmanagement_InstallFolder_"] [class*="contentmanagement_FolderInfo_"] [class*="contentmanagement_DriveName_"]
+.ModalDialogPopup div[class*="contentmanagement_InstallFolder_"] div[class*="contentmanagement_FolderInfo_"] div[class*="contentmanagement_DriveName_"]
 {
 	font-size: 14px !important;
 	font-weight: 700 !important;
 }
 
-[class*="contentmanagement_InstallFolder_"] [class*="contentmanagement_FolderInfo_"] [class*="contentmanagement_DriveSize_"]
+.ModalDialogPopup div[class*="contentmanagement_InstallFolder_"] div[class*="contentmanagement_FolderInfo_"] div[class*="contentmanagement_DriveSize_"]
 {
 	font-size: 10px !important;
 	font-weight: 400 !important;
 	opacity: 0.5 !important;
 }
 
-[class*="contentmanagement_AddFolder_"]
+.ModalDialogPopup div[class*="contentmanagement_AddFolder_"]
 {
 	width: 34px !important;
 	height: 34px !important;
@@ -134,27 +134,27 @@
 	padding: 9px !important;
 }
 
-[class*="contentmanagement_AddFolder_"] > svg
+.ModalDialogPopup div[class*="contentmanagement_AddFolder_"] > svg
 {
 	margin-right: 0 !important;
 }
 
-[class*="contentmanagement_ContentManagement_"] [class*="pageablecontainer_HeaderPageControls_"]
+.ModalDialogPopup .DialogBody[class*="contentmanagement_ContentManagement_"] div[class*="pageablecontainer_HeaderPageControls_"]
 {
 	display: none !important;
 }
 
-[class*="contentmanagement_LibraryContent_"]
+.ModalDialogPopup div[class*="contentmanagement_LibraryContent_"]
 {
 	padding: 0 !important;
 }
 
-[class*="contentmanagement_LibraryHeader_"]
+.ModalDialogPopup div[class*="contentmanagement_LibraryHeader_"]
 {
 	padding: 8px 8px 0 8px !important;
 }
 
-[class*="contentmanagement_LibraryHeader_"] [class*="contentmanagement_DriveUsage_"] [class*="contentmanagement_DriveName_"]
+.ModalDialogPopup div[class*="contentmanagement_LibraryHeader_"] div[class*="contentmanagement_DriveUsage_"] div[class*="contentmanagement_DriveName_"]
 {
 	color: var(--window_fg) !important;
 	text-transform: none !important;
@@ -165,57 +165,57 @@
 	font-weight: 700 !important;
 }
 
-[class*="contentmanagement_DriveSettingsButton_"]
+.ModalDialogPopup div[class*="contentmanagement_DriveSettingsButton_"]
 {
 	background: var(--button_bg);
 	border-radius: var(--button_radius);
 	transition: var(--focus_transition) !important;
 }
 
-[class*="contentmanagement_DriveSettingsButton_"]:hover
+.ModalDialogPopup div[class*="contentmanagement_DriveSettingsButton_"]:hover
 {
 	background: var(--button_hover_bg);
 }
 
-[class*="contentmanagement_DriveSettingsButton_"]:active
+.ModalDialogPopup div[class*="contentmanagement_DriveSettingsButton_"]:active
 {
 	background: var(--button_active_bg);
 }
 
-[class*="contentmanagement_AppsGrid_"] .ReactVirtualized__Grid__innerScrollContainer
+.ModalDialogPopup div[class*="contentmanagement_AppsGrid_"] .ReactVirtualized__Grid__innerScrollContainer
 {
 	pointer-events: all !important;
 }
 
-[class*="contentmanagement_AppBody_"]
+.ModalDialogPopup div[class*="contentmanagement_AppBody_"]
 {
 	border-radius: var(--entry_radius) !important;
 	transition: var(--focus_transition) !important;
 }
 
-[class*="contentmanagement_AppBody_"]:hover
+.ModalDialogPopup div[class*="contentmanagement_AppBody_"]:hover
 {
 	background: var(--entry_hover_bg) !important;
 }
 
-[class*="contentmanagement_AppActionBar_"]
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"]
 {
 	flex-direction: row-reverse !important;
 	overflow: hidden !important;
 	padding: 0 !important;
 }
 
-[class*="contentmanagement_AppActionBar_"] [class*="contentmanagement_AppActionSelected_"]
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"] div[class*="contentmanagement_AppActionSelected_"]
 {
 	display: none !important;
 }
 
-[class*="contentmanagement_AppActionBarButtons_"]
+.ModalDialogPopup div[class*="contentmanagement_AppActionBarButtons_"]
 {
 	width: 100% !important;
 }
 
-[class*="contentmanagement_AppActionBar_"] .DialogButton
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"] .DialogButton
 {
 	height: 42px !important;
 	color: var(--button_fg) !important;
@@ -237,45 +237,45 @@
 	flex-grow: 1 !important;
 }
 
-[class*="contentmanagement_AppActionBar_"] .DialogButton::before
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"] .DialogButton::before
 {
 	display: none !important;
 }
 
-[class*="contentmanagement_AppActionBar_"] .DialogButton.Disabled
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"] .DialogButton.Disabled
 {
 	color: var(--button_disabled_fg) !important;
 }
 
-[class*="contentmanagement_AppActionBar_"] .DialogButton:hover
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"] .DialogButton:hover
 {
 	background: rgba(255, 255, 255, 0.07) !important;
 	box-shadow: none !important;
 }
 
-[class*="contentmanagement_AppActionBar_"] .DialogButton:active
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"] .DialogButton:active
 {
 	background: rgba(255, 255, 255, 0.16) !important;
 	box-shadow: none !important;
 }
 
 /* Uninstall button */
-[class*="contentmanagement_AppActionBar_"] .DialogButton:not(:last-child)
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"] .DialogButton:not(:last-child)
 {
 	color: var(--destructive) !important;
 }
 
-[class*="contentmanagement_AppActionBar_"] .DialogButton:not(:last-child).Disabled
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"] .DialogButton:not(:last-child).Disabled
 {
 	color: var(--destructive_disabled) !important;
 }
 
-[class*="contentmanagement_AppActionBar_"] .DialogButton:not(:last-child):hover
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"] .DialogButton:not(:last-child):hover
 {
 	background: var(--destructive_hover_bg) !important;
 }
 
-[class*="contentmanagement_AppActionBar_"] .DialogButton:not(:last-child):active
+.ModalDialogPopup div[class*="contentmanagement_AppActionBar_"] .DialogButton:not(:last-child):active
 {
 	background: var(--destructive_active_bg) !important;
 }

--- a/extras/web/full/dialogs/friends_settings.css
+++ b/extras/web/full/dialogs/friends_settings.css
@@ -19,8 +19,8 @@
 .FriendSettingsContainer ._DialogInputContainer,
 .FriendSettingsContainer .FriendsSettingsNotificationRow:not(.FriendsSettingsNotificationRow_Header),
 .FriendSettingsContainer .voiceMicTestContainer,
-.FriendSettingsContainer [class*="toggle_ToggleRow_"],
-.FriendSettingsContainer [class*="voicesettings_TransmissionTypeSettings_"]
+.FriendSettingsContainer div[class*="toggle_ToggleRow_"],
+.FriendSettingsContainer div[class*="voicesettings_TransmissionTypeSettings_"]
 {
 	background: var(--card_bg) !important;
 	border-radius: var(--card_radius) !important;
@@ -40,7 +40,7 @@
 .FriendSettingsContainer .FriendsSettingsFlashSection_ButtonRow,
 .FriendSettingsContainer .DialogToggleField_Control,
 .FriendSettingsContainer .voiceSelfDirections,
-.FriendSettingsContainer [class*="radio_Group_"],
+.FriendSettingsContainer div[class*="radio_Group_"],
 .FriendSettingsContainer .advancedSettings.showAdvanced
 {
 	background: none !important;
@@ -97,7 +97,7 @@
 
 .FriendSettingsContainer .DialogToggleField_Option.Off,
 .FriendSettingsContainer .DialogToggleField_Option.On,
-.FriendSettingsContainer [class*="radio_Button_"]
+.FriendSettingsContainer div[class*="radio_Button_"]
 {
 	background: var(--button_disabled_bg) !important;
 	color: var(--button_disabled_fg) !important;
@@ -106,7 +106,7 @@
 
 .FriendSettingsContainer .DialogToggleField_Option.Off.Active,
 .FriendSettingsContainer .DialogToggleField_Option.On.Active,
-.FriendSettingsContainer [class*="radio_Active_"]
+.FriendSettingsContainer div[class*="radio_Active_"]
 {
 	background: var(--button_bg) !important;
 	color: var(--fg) !important;
@@ -117,14 +117,14 @@
 
 .FriendSettingsContainer .DialogToggleField_Option.Off:hover,
 .FriendSettingsContainer .DialogToggleField_Option.On:hover,
-.FriendSettingsContainer [class*="radio_Button_"]:hover
+.FriendSettingsContainer div[class*="radio_Button_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 }
 
 .FriendSettingsContainer .DialogToggleField_Option.Off:active,
 .FriendSettingsContainer .DialogToggleField_Option.On:active,
-.FriendSettingsContainer [class*="radio_Button_"]:active
+.FriendSettingsContainer div[class*="radio_Button_"]:active
 {
 	background: var(--button_active_bg) !important;
 }
@@ -207,25 +207,25 @@
 }
 
 /* Radio Group */
-.FriendSettingsContainer [class*="radio_Group_"]
+.FriendSettingsContainer div[class*="radio_Group_"]
 {
 	box-shadow: none !important;
 }
 
-.FriendSettingsContainer [class*="radio_Group_"] [class*="voicesettings_RecommendedNote_"]
+.FriendSettingsContainer div[class*="radio_Group_"] span[class*="voicesettings_RecommendedNote_"]
 {
 	font-weight: var(--label_weight) !important;
 }
 
 /* Advanced Settings */
-.FriendSettingsContainer [class*="toggle_ToggleRow_"]
+.FriendSettingsContainer div[class*="toggle_ToggleRow_"]
 {
 	padding-right: 20px !important;
 	margin-bottom: 1px !important;
 }
 
-.FriendSettingsContainer [class*="toggle_ToggleRow_"] [class*="toggle_Label_"],
-.FriendSettingsContainer [class*="voicesettings_HotkeySettingRow_"] [class*="voicesettings_HotkeySettingDescription_"]
+.FriendSettingsContainer div[class*="toggle_ToggleRow_"] div[class*="toggle_Label_"],
+.FriendSettingsContainer div[class*="voicesettings_HotkeySettingRow_"] [class*="voicesettings_HotkeySettingDescription_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -233,7 +233,7 @@
 	font-weight: var(--entry_font_weight) !important;
 }
 
-.FriendSettingsContainer .VoiceSettings .showAdvanced > .DialogLabel + [class*="toggle_ToggleRow_"]
+.FriendSettingsContainer .VoiceSettings .showAdvanced > .DialogLabel + div[class*="toggle_ToggleRow_"]
 {
 	border-bottom-left-radius: 0px !important;
 	border-bottom-right-radius: 0px !important;
@@ -241,12 +241,12 @@
 	border-top-right-radius: var(--entry_radius) !important;
 }
 
-.FriendSettingsContainer .VoiceSettings .showAdvanced [class*="toggle_ToggleRow_"] + [class*="toggle_ToggleRow_"]
+.FriendSettingsContainer .VoiceSettings .showAdvanced div[class*="toggle_ToggleRow_"] + div[class*="toggle_ToggleRow_"]
 {
 	border-radius: 0px !important;
 }
 
-.FriendSettingsContainer .VoiceSettings .showAdvanced [class*="toggle_ToggleRow_"]:nth-of-type(5)
+.FriendSettingsContainer .VoiceSettings .showAdvanced div[class*="toggle_ToggleRow_"]:nth-of-type(5)
 {
 	border-bottom-left-radius: var(--entry_radius) !important;
 	border-bottom-right-radius: var(--entry_radius) !important;

--- a/extras/web/full/dialogs/paged_settings.css
+++ b/extras/web/full/dialogs/paged_settings.css
@@ -1,20 +1,20 @@
 /* --- Paged Settings --- */
 .ModalDialogPopup .DialogContent:not(.GenericConfirmDialog),
 .ModalDialogPopup .DialogContent:not(.GenericConfirmDialog) .DialogContentTransition,
-.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListColumn_"]
+.ModalDialogPopup div[class*="pagedsettings_PagedSettingsDialog_PageListColumn_"]
 {
 	background: var(--window_bg) !important;
 	color: var(--window_fg) !important;
 	padding: 0 !important;
 }
 
-.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListColumn_"]
+.ModalDialogPopup div[class*="pagedsettings_PagedSettingsDialog_PageListColumn_"]
 {
 	border-right: 1px var(--border) solid !important;
 }
 
 .ModalDialogPopup .DialogContent:not(.GenericConfirmDialog) .DialogHeader,
-.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListColumn_"] > [class*="pagedsettings_PagedSettingsDialog_Title_"]
+.ModalDialogPopup div[class*="pagedsettings_PagedSettingsDialog_PageListColumn_"] > div[class*="pagedsettings_PagedSettingsDialog_Title_"]
 {
 	box-sizing: border-box !important;
 	height: 48px !important;
@@ -43,13 +43,13 @@
 	display: none !important;
 }
 
-.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListColumn_"] > div[class*="pagedsettings_PagedSettingsDialog_Title_"]
+.ModalDialogPopup div[class*="pagedsettings_PagedSettingsDialog_PageListColumn_"] > div[class*="pagedsettings_PagedSettingsDialog_Title_"]
 {
 	margin-bottom: 5px !important;
 }
 
 .ModalDialogPopup:focus-within .DialogContent:not(.GenericConfirmDialog) .DialogHeader,
-.ModalDialogPopup:focus-within [class*="pagedsettings_PagedSettingsDialog_PageListColumn_"] > [class*="pagedsettings_PagedSettingsDialog_Title_"]
+.ModalDialogPopup:focus-within div[class*="pagedsettings_PagedSettingsDialog_PageListColumn_"] > div[class*="pagedsettings_PagedSettingsDialog_Title_"]
 {
 	background: var(--headerbar_bg) !important;
 }
@@ -59,7 +59,7 @@
 	height: 48px !important;
 }
 
-.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListItem_"]
+.ModalDialogPopup div[class*="pagedsettings_PagedSettingsDialog_PageListItem_"]
 {
 	color: var(--button_fg) !important;
 	font-family: var(--basefont) !important;
@@ -76,27 +76,27 @@
 	border-radius: var(--button_radius) !important;
 }
 
-.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListItem_"]:hover
+.ModalDialogPopup div[class*="pagedsettings_PagedSettingsDialog_PageListItem_"]:hover
 {
 	background-color: rgba(255, 255, 255, 0.07) !important;
 }
 
-.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListItem_"]:active
+.ModalDialogPopup div[class*="pagedsettings_PagedSettingsDialog_PageListItem_"]:active
 {
 	background-color: rgba(255, 255, 255, 0.16) !important;
 }
 
-.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListItem_"][class*="pagedsettings_Active_"]
+.ModalDialogPopup div[class*="pagedsettings_PagedSettingsDialog_PageListItem_"][class*="pagedsettings_Active_"]
 {
 	background-color: rgba(255, 255, 255, 0.1) !important;
 }
 
-.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListItem_"][class*="pagedsettings_Active_"]:hover
+.ModalDialogPopup div[class*="pagedsettings_PagedSettingsDialog_PageListItem_"][class*="pagedsettings_Active_"]:hover
 {
 	background-color: rgba(255, 255, 255, 0.13) !important;
 }
 
-.ModalDialogPopup [class*="pagedsettings_PagedSettingsDialog_PageListItem_"][class*="pagedsettings_Active_"]:active
+.ModalDialogPopup div[class*="pagedsettings_PagedSettingsDialog_PageListItem_"][class*="pagedsettings_Active_"]:active
 {
 	background-color: rgba(255, 255, 255, 0.19) !important;
 }

--- a/extras/web/full/dialogs/whats_new.css
+++ b/extras/web/full/dialogs/whats_new.css
@@ -1,16 +1,16 @@
 /* --- Whats New Dialog --- */
-[class*="libraryhomenewupdates_WhatsNewSettingsContent_"]
+.ModalDialogPopup div[class*="libraryhomenewupdates_WhatsNewSettingsContent_"]
 {
 	background: var(--bg) !important;
 	padding: 0px !important;
 }
 
-[class*="libraryhomenewupdates_WhatsNewSettings_"]
+.ModalDialogPopup form[class*="libraryhomenewupdates_WhatsNewSettings_"]
 {
 	padding: 24px !important;
 }
 
-[class*="libraryhomenewupdates_WhatsNewSettingsContent_"] .DialogHeader
+.ModalDialogPopup div[class*="libraryhomenewupdates_WhatsNewSettingsContent_"] .DialogHeader
 {
 	align-items: center !important;
 	background: var(--headerbar_backdrop) !important;
@@ -31,12 +31,12 @@
 	width: 100%;
 }
 
-.ModalDialogPopup:focus-within [class*="libraryhomenewupdates_WhatsNewSettingsContent_"] .DialogHeader
+.ModalDialogPopup:focus-within div[class*="libraryhomenewupdates_WhatsNewSettingsContent_"] .DialogHeader
 {
 	background: var(--headerbar_bg) !important;
 }
 
-[class*="libraryhomenewupdates_WhatsNewSettingsContent_"] ._DialogInputContainer
+.ModalDialogPopup div[class*="libraryhomenewupdates_WhatsNewSettingsContent_"] ._DialogInputContainer
 {
 	align-items: center !important;
 	background: var(--entry_bg) !important;
@@ -52,7 +52,7 @@
 	padding: var(--entry_padding);
 }
 
-[class*="libraryhomenewupdates_DialogLabelSoft_"]
+.ModalDialogPopup div[class*="libraryhomenewupdates_DialogLabelSoft_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -60,7 +60,7 @@
 	font-weight: var(--baseweight) !important;
 }
 
-[class*="libraryhomenewupdates_WhatsNewSettingsContent_"] .DialogToggle_Description
+.ModalDialogPopup div[class*="libraryhomenewupdates_WhatsNewSettingsContent_"] .DialogToggle_Description
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;

--- a/extras/web/full/downloads.css
+++ b/extras/web/full/downloads.css
@@ -1,39 +1,39 @@
 /* Fix Logo Border */
-[class*="downloadgraph_HeroContainer"] [class*="libraryassetimage_Visible_"]
+#SteamDesktop div[class*="downloadgraph_HeroContainer"] img[class*="libraryassetimage_Visible_"]
 {
 	background: none !important;
 }
 
 /* Top Right Settings Button */
-[class*="downloadgraph_SettingsButton_"] button,
-[class*="downloadgraph_SettingsButton_"] button:hover
+#SteamDesktop div[class*="downloadgraph_SettingsButton_"] button,
+#SteamDesktop div[class*="downloadgraph_SettingsButton_"] button:hover
 {
 	border-radius: var(--button_radius) !important;
 }
 
 /* Download Items */
-[class*="downloads_SectionItem_"]
+#SteamDesktop div[class*="downloads_SectionItem_"]
 {
 	border-radius: var(--card_radius) !important;
 }
 
-[class*="downloads_SectionItem_"]:hover
+#SteamDesktop div[class*="downloads_SectionItem_"]:hover
 {
 	border-radius: var(--card_radius) !important;
 }
 
 /* Active Download Item */
-[class*="downloads_SectionItem_"][class*="downloads_Active_"]
+#SteamDesktop div[class*="downloads_SectionItem_"][class*="downloads_Active_"]
 {
 	margin: 10px 12px 0px 12px !important;
 	padding: 8px 0px 8px 12px !important;
 }
 
 /* Download Buttons */
-[class*="downloads_Button_"],
-[class*="downloads_Button_"]:hover,
-[class*="downloads_RemoveAllButton_"],
-[class*="downloads_RemoveAllButton_"]:hover
+#SteamDesktop button[class*="downloads_Button_"],
+#SteamDesktop button[class*="downloads_Button_"]:hover,
+#SteamDesktop button[class*="downloads_RemoveAllButton_"],
+#SteamDesktop button[class*="downloads_RemoveAllButton_"]:hover
 {
 	border-radius: var(--button_radius) !important;
 }

--- a/extras/web/full/game_details.css
+++ b/extras/web/full/game_details.css
@@ -1,47 +1,47 @@
 /* Rounded Corners */
-[class*="appactionbutton_ButtonChild"],
-[class*="appactivityday_EventBody_"],
-[class*="appactivityday_PartnerEventMediumImage_Image_"],
-[class*="appactivityday_PartnerEventLargeImage_Image_"],
-[class*="appactivityday_PartnerEventLargeImage_Container_"],
-[class*="appactivityday_PartnerEvent_"],
-[class*="appdetailsactivitysection_FetchMoreContainer_"],
-[class*="appdetailscommunityfeed_HeaderStyles_"],
-[class*="appdetailsdlcsection_Art_"],
-[class*="appdetailsprimarylinkssection_LinksSectionBody_"],
-[class*="appdetailssection_Highlight_"],
-[class*="appdetailssection_RightColumnSection_"],
-[class*="appdetailsspotlight_ReviewContainer_"],
-[class*="appdetailsworkshopsection_FeaturedItemImage_"],
-[class*="appdetailsworkshopsection_WorkshopContainer_"],
-[class*="libraryassetimage_Visible_"],
-[class*="spotlight_MajorEventImageContainer_"],
-[class*="spotlight_MajorEventContainer_"],
-[class*="spotlight_MajorEventBackground_"],
-[class*="writereview_RightContainer_"] button,
-[class*="appdetailsgameinfopanel_Description_"],
-[class*="appactivitydlc_Contents_"],
-[class*="discussionwidget_VoteContainer_"],
-[class*="discussionwidget_ShareContainer_"],
-[class*="discussionwidget_DiscussContainer_"]
+#SteamDesktop div[class*="appactionbutton_ButtonChild"],
+#SteamDesktop div[class*="appactivityday_EventBody_"],
+#SteamDesktop img[class*="appactivityday_PartnerEventMediumImage_Image_"],
+#SteamDesktop img[class*="appactivityday_PartnerEventLargeImage_Image_"],
+#SteamDesktop div[class*="appactivityday_PartnerEventLargeImage_Container_"],
+#SteamDesktop div[class*="appactivityday_PartnerEvent_"],
+#SteamDesktop button[class*="appdetailsactivitysection_FetchMoreContainer_"],
+#SteamDesktop div[class*="appdetailscommunityfeed_HeaderStyles_"],
+#SteamDesktop div[class*="appdetailsdlcsection_Art_"],
+#SteamDesktop div[class*="appdetailsprimarylinkssection_LinksSectionBody_"],
+#SteamDesktop div[class*="appdetailssection_Highlight_"],
+#SteamDesktop div[class*="appdetailssection_RightColumnSection_"],
+#SteamDesktop div[class*="appdetailsspotlight_ReviewContainer_"],
+#SteamDesktop img[class*="appdetailsworkshopsection_FeaturedItemImage_"],
+#SteamDesktop div[class*="appdetailsworkshopsection_WorkshopContainer_"],
+#SteamDesktop img[class*="libraryassetimage_Visible_"],
+#SteamDesktop div[class*="spotlight_MajorEventImageContainer_"],
+#SteamDesktop div[class*="spotlight_MajorEventContainer_"],
+#SteamDesktop [class*="spotlight_MajorEventBackground_"],
+#SteamDesktop div[class*="writereview_RightContainer_"] button,
+#SteamDesktop div[class*="appdetailsgameinfopanel_Description_"],
+#SteamDesktop div[class*="appactivitydlc_Contents_"],
+#SteamDesktop div[class*="discussionwidget_VoteContainer_"],
+#SteamDesktop div[class*="discussionwidget_ShareContainer_"],
+#SteamDesktop div[class*="discussionwidget_DiscussContainer_"]
 {
 	border-radius: var(--card_radius) !important;
 	background: var(--card_bg) !important;
 	border: none !important;
 }
 
-[class*="appdetailsachievementssection_AdditionalItem_"],
-[class*="appdetailscommunityfeed_LoadContentButton_"],
-[class*="appdetailsactivitysection_ViewLastNews_"]
+#SteamDesktop div[class*="appdetailsachievementssection_AdditionalItem_"],
+#SteamDesktop div[class*="appdetailscommunityfeed_LoadContentButton_"],
+#SteamDesktop div[class*="appdetailsactivitysection_ViewLastNews_"]
 {
 	border-radius: var(--button_radius) !important;
 	background: var(--button_bg) !important;
 	border: none !important;
 }
 
-[class*="appdetailsactivitysection_FetchMoreContainer_"],
-[class*="appdetailscommunityfeed_LoadContentButton_"],
-[class*="appdetailsactivitysection_ViewLastNews_"]
+#SteamDesktop button[class*="appdetailsactivitysection_FetchMoreContainer_"],
+#SteamDesktop div[class*="appdetailscommunityfeed_LoadContentButton_"],
+#SteamDesktop div[class*="appdetailsactivitysection_ViewLastNews_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -51,32 +51,32 @@
 }
 
 /* Play button, streaming device dropdown */
-[class*="appactionbutton_PlayButtonContainer"]
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"]
 {
 	border-radius: var(--button_radius) !important;
 	background-color: var(--accent_bg) !important;
 	color: var(--accent_fg) !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"],
-[class*="appactionbutton_ShowingStreaming"]
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"],
+#SteamDesktop [class*="appactionbutton_ShowingStreaming"]
 {
 	min-width: 140px !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"][class*="appactionbutton_Green"]
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"][class*="appactionbutton_Green"]
 {
 	background-color: var(--success_bg) !important;
 	color: var(--success_fg) !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"][class*="appactionbutton_Disabled"]
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"][class*="appactionbutton_Disabled"]
 {
 	background-color: var(--button_disabled_bg) !important;
 	color: var(--button_disabled_fg) !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"] [class*="appactionbutton_ButtonText"]
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"] div[class*="appactionbutton_ButtonText"]
 {
 	color: var(--button_fg) !important;
 	font-family: var(--basefont) !important;
@@ -87,19 +87,19 @@
 	text-transform: none !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"] > [class*="appactionbutton_ButtonChild"]:first-child > svg
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"] > div[class*="appactionbutton_ButtonChild"]:first-child > svg
 {
 	display: none !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"] > [class*="appactionbutton_ButtonChild"] > svg > path,
-[class*="appactionbutton_PlayButtonContainer"] > [class*="appactionbutton_ButtonChild"] > svg > polygon
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"] > div[class*="appactionbutton_ButtonChild"] > svg > path,
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"] > div[class*="appactionbutton_ButtonChild"] > svg > polygon
 {
 	stroke: currentColor !important;
 	fill: currentColor !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"] > [class*="appactionbutton_ButtonChild"]
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"] > div[class*="appactionbutton_ButtonChild"]
 {
 	margin: 0 !important;
 	border-radius: var(--button_radius) !important;
@@ -107,83 +107,83 @@
 	transition: background 0.15s, border-color 0.15s, border-top-left-radius 0s, border-bottom-left-radius 0s !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"] > [class*="appactionbutton_ButtonChild"]:hover
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"] > div[class*="appactionbutton_ButtonChild"]:hover
 {
 	background-color: var(--button_hover_bg) !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"] > [class*="appactionbutton_ButtonChild"]:active
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"] > div[class*="appactionbutton_ButtonChild"]:active
 {
 	background-color: var(--button_active_bg) !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"] > [class*="appactionbutton_ButtonChild"]:last-child:not(:first-child)
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"] > div[class*="appactionbutton_ButtonChild"]:last-child:not(:first-child)
 {
 	border-top-left-radius: 0 !important;
 	border-bottom-left-radius: 0 !important;
 	border-left: 1px var(--button_active_bg) solid !important;
 }
 
-[class*="appactionbutton_PlayButtonContainer"]:hover > [class*="appactionbutton_ButtonChild"]:last-child:not(:first-child)
+#SteamDesktop div[class*="appactionbutton_PlayButtonContainer"]:hover > div[class*="appactionbutton_ButtonChild"]:last-child:not(:first-child)
 {
 	border-radius: var(--button_radius) !important;
 	border-color: transparent !important;
 }
 
 /* Hover Highlight */
-[class*="appactivityday_PartnerEventTextOnly_Container_"]:hover,
-[class*="appactivityday_PartnerEventMediumImage_Container_"]:hover,
-[class*="appactivityday_PartnerEventLargeImage_Container_"]:hover,
-[class*="appdetailsachievementssection_AdditionalItem_"]:hover,
-[class*="appdetailscommunityfeed_LoadContentButton_"]:hover,
-[class*="appdetailsactivitysection_FetchMoreContainer_"]:hover,
-[class*="appdetailsactivitysection_ViewLastNews_"]:hover
+#SteamDesktop div[class*="appactivityday_PartnerEventTextOnly_Container_"]:hover,
+#SteamDesktop div[class*="appactivityday_PartnerEventMediumImage_Container_"]:hover,
+#SteamDesktop div[class*="appactivityday_PartnerEventLargeImage_Container_"]:hover,
+#SteamDesktop div[class*="appdetailsachievementssection_AdditionalItem_"]:hover,
+#SteamDesktop div[class*="appdetailscommunityfeed_LoadContentButton_"]:hover,
+#SteamDesktop button[class*="appdetailsactivitysection_FetchMoreContainer_"]:hover,
+#SteamDesktop div[class*="appdetailsactivitysection_ViewLastNews_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 }
 
-[class*="appactivityday_PartnerEventTextOnly_Container_"],
-[class*="appactivityday_PartnerEventMediumImage_Container_"],
-[class*="appactivityday_PartnerEventLargeImage_Container_"]
+#SteamDesktop div[class*="appactivityday_PartnerEventTextOnly_Container_"],
+#SteamDesktop div[class*="appactivityday_PartnerEventMediumImage_Container_"],
+#SteamDesktop div[class*="appactivityday_PartnerEventLargeImage_Container_"]
 {
 	border-radius: var(--card_radius) !important;
 }
 
 /* Remove Unneeded Backgrounds */
-[class*="appactivityday_PartnerEventMediumImage_Container_"],
-[class*="appdetailsdlcsection_Gloss_"],
-[class*="writereview_RatingContainer_"],
-[class*="appdetailsgameinfopanel_Container_"],
-[class*="appactivityday_LeftSideMajorUpdateBar_"],
-[class*="appactivityday_PartnerEventLargeUpdate_"]
+#SteamDesktop div[class*="appactivityday_PartnerEventMediumImage_Container_"],
+#SteamDesktop div[class*="appdetailsdlcsection_Gloss_"],
+#SteamDesktop div[class*="writereview_RatingContainer_"],
+#SteamDesktop div[class*="appdetailsgameinfopanel_Container_"],
+#SteamDesktop div[class*="appactivityday_LeftSideMajorUpdateBar_"],
+#SteamDesktop div[class*="appactivityday_PartnerEventLargeUpdate_"]
 {
 	background: none !important;
 }
 
 /* Remove Image Borders */
-[class*="appactivityday_PartnerEvent_"],
-[class*="appactivityday_PartnerEventLargeUpdate_"],
-[class*="spotlight_MajorEventContainer_"],
-[class*="appactivityday_PartnerEventLargeUpdate_"]
+#SteamDesktop div[class*="appactivityday_PartnerEvent_"],
+#SteamDesktop div[class*="appactivityday_PartnerEventLargeUpdate_"],
+#SteamDesktop div[class*="spotlight_MajorEventContainer_"],
+#SteamDesktop div[class*="appactivityday_PartnerEventLargeUpdate_"]
 {
 	border-image-source: none !important;
 }
 
 /* Border Radius Fixes */
-[class*="appdetailsworkshopsection_WorkshopContainer_"]
+#SteamDesktop div[class*="appdetailsworkshopsection_WorkshopContainer_"]
 {
 	border-top-left-radius: 0px !important;
 	border-top-right-radius: 0px !important;
 }
 
-[class*="appdetailsworkshopsection_WorkshopHightlight_"]
+#SteamDesktop div[class*="appdetailsworkshopsection_WorkshopHightlight_"]
 {
 	border-bottom-left-radius: 0px !important;
 	border-bottom-right-radius: 0px !important;
 }
 
-[class*="appdetailsachievementssection_Icon_"],
-[class*="appdetailsachievementssection_AdditionalItem_"]
+#SteamDesktop div[class*="appdetailsachievementssection_Icon_"],
+#SteamDesktop div[class*="appdetailsachievementssection_AdditionalItem_"]
 {
 	border-radius: var(--button_radius) !important;
 }
@@ -195,35 +195,35 @@
 }
 
 /* Hide Blur From Major Updates */
-[class*="appactivityday_Blur_"]
+#SteamDesktop img[class*="appactivityday_Blur_"]
 {
 	display:none;
 }
 
 /* Partner Updates */
-[class*="appactivityday_PartnerEventLargeUpdate_"],
-[class*="appactivityday_PartnerEventFeatured_"]
+#SteamDesktop div[class*="appactivityday_PartnerEventLargeUpdate_"],
+#SteamDesktop [class*="appactivityday_PartnerEventFeatured_"]
 {
 	box-shadow: none !important;
 }
 
-[class*="appactivityday_PartnerEventTypeUpdate_"]
+#SteamDesktop div[class*="appactivityday_PartnerEventTypeUpdate_"]
 {
 	color: var(--fg) !important;
 	text-shadow: none !important;
 }
 
-[class*="appactivityday_PartnerEventLargeImage_Summary_"]
+#SteamDesktop div[class*="appactivityday_PartnerEventLargeImage_Summary_"]
 {
 	color: #929799 !important;
 }
 
-[class*="appactivityday_PartnerEventFeaturedHeader_"]
+#SteamDesktop [class*="appactivityday_PartnerEventFeaturedHeader_"]
 {
 	background: none !important;
 }
 
-[class*="appactivityday_PartnerEventType_"]
+#SteamDesktop div[class*="appactivityday_PartnerEventType_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -232,8 +232,8 @@
 	text-shadow: none !important;
 }
 
-[class*="appactivityday_PartnerEventMediumImage_Title_"],
-[class*="appactivityday_PartnerEventLargeImage_Title_"]
+#SteamDesktop div[class*="appactivityday_PartnerEventMediumImage_Title_"],
+#SteamDesktop div[class*="appactivityday_PartnerEventLargeImage_Title_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -242,9 +242,9 @@
 	text-shadow: none !important;
 }
 
-[class*="appactivityday_PartnerEventMediumImage_Summary_"],
-[class*="appactivityday_PartnerEventLargeImage_Summary_"],
-[class*="appactivityday_PartnerEventTextOnly_Summary_"]
+#SteamDesktop div[class*="appactivityday_PartnerEventMediumImage_Summary_"],
+#SteamDesktop div[class*="appactivityday_PartnerEventLargeImage_Summary_"],
+#SteamDesktop span[class*="appactivityday_PartnerEventTextOnly_Summary_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -252,7 +252,7 @@
 	text-shadow: none !important;
 }
 
-[class*="appactivityday_PartnerEventTextOnly_Title_"]
+#SteamDesktop div[class*="appactivityday_PartnerEventTextOnly_Title_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -260,18 +260,18 @@
 	text-shadow: none !important;
 }
 
-[class*="appactivityday_PartnerEventTextOnly_Icon_"] svg path
+#SteamDesktop div[class*="appactivityday_PartnerEventTextOnly_Icon_"] svg path
 {
 	fill: var(--dim_label_fg) !important;
 }
 
-[class*="appactivityday_Event_"] [class*="comment_thread_RatingBar_"]
+#SteamDesktop div[class*="appactivityday_Event_"] div[class*="comment_thread_RatingBar_"]
 {
 	margin-top: 4px !important;
 }
 
 /* Achievement Activity */
-[class*="appdetailsachievementssection_Name_"]
+#SteamDesktop div[class*="appdetailsachievementssection_Name_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -279,7 +279,7 @@
 	font-weight: var(--title_3_weight) !important;
 }
 
-[class*="appdetailsachievementssection_Desc_"]
+#SteamDesktop div[class*="appdetailsachievementssection_Desc_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -287,20 +287,20 @@
 }
 
 /* Fetch More */
-[class*="appdetailsactivitysection_FetchMoreContainer_"]::before,
-[class*="appdetailsactivitysection_FetchMoreContainer_"]:active
+#SteamDesktop button[class*="appdetailsactivitysection_FetchMoreContainer_"]::before,
+#SteamDesktop button[class*="appdetailsactivitysection_FetchMoreContainer_"]:active
 {
 	box-shadow: none !important;
 }
 
-[class*="appdetailsactivitysection_FetchMoreContainer_"].Disabled
+#SteamDesktop button[class*="appdetailsactivitysection_FetchMoreContainer_"].Disabled
 {
 	background-color: var(--button_disabled_bg) !important;
 	color: var(--button_disabled_fg) !important;
 }
 
 /* Pop Up Update */
-[class*="apppartnereventspage_PartnerEvent_"]
+#SteamDesktop div[class*="apppartnereventspage_PartnerEvent_"]
 {
 	border-radius: var(--popover_radius) !important;
 	background: var(--popover_bg) !important;
@@ -308,29 +308,29 @@
 	box-shadow: none !important;
 }
 
-[class*="partnereventdisplay_EventBackgroundBlur_"]
+#SteamDesktop img[class*="partnereventdisplay_EventBackgroundBlur_"]
 {
 	display: none !important;
 }
 
-[class*="apppartnereventspage_EventType_"],
-[class*="discussionwidget_VoteCount_"],
-[class*="discussionwidget_DiscussionCount_"]
+#SteamDesktop span[class*="apppartnereventspage_EventType_"],
+#SteamDesktop div[class*="discussionwidget_VoteCount_"],
+#SteamDesktop div[class*="discussionwidget_DiscussionCount_"]
 {
 	color: var(--accent) !important;
 	font-family: var(--basefont) !important;
 	font-weight: var(--title_4_weight) !important;
 }
 
-[class*="partnereventdisplay_EventDetailTimeInfo_"] [class*="localdateandtime_ShortDateAndTime_"],
-[class*="partnereventdisplay_EventDetailTimeInfo_"] [class*="localdateandtime_RightSideTitles_"]
+#SteamDesktop div[class*="partnereventdisplay_EventDetailTimeInfo_"] div[class*="localdateandtime_ShortDateAndTime_"],
+#SteamDesktop div[class*="partnereventdisplay_EventDetailTimeInfo_"] div[class*="localdateandtime_RightSideTitles_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
 	font-weight: var(--baseweight) !important;
 }
 
-[class*="partnereventdisplay_EventDetailTitle_"]
+#SteamDesktop a[class*="partnereventdisplay_EventDetailTitle_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -338,7 +338,7 @@
 	font-weight: var(--title_1_weight) !important;
 }
 
-[class*="partnereventdisplay_EventDetailsSubTitle_"]
+#SteamDesktop div[class*="partnereventdisplay_EventDetailsSubTitle_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -346,63 +346,63 @@
 	font-weight: var(--title_3_weight) !important;
 }
 
-[class*="apppartnereventspage_CloseButton_"]
+#SteamDesktop div[class*="apppartnereventspage_CloseButton_"]
 {
 	background: var(--popover_bg) !important;
 	height: 24px !important;
 	width: 24px !important;
 }
 
-[class*="apppartnereventspage_CloseButton_"] svg line
+#SteamDesktop div[class*="apppartnereventspage_CloseButton_"] svg line
 {
 	stroke: var(--headerbar_fg) !important;
 	stroke-width: 32px !important;
 }
 
-[class*="apppartnereventspage_ScrollButton_"]
+#SteamDesktop div[class*="apppartnereventspage_ScrollButton_"]
 {
 	background: var(--popover_bg) !important;
 	height: 24px !important;
 	width: 40px !important;
 }
 
-[class*="apppartnereventspage_ScrollButton_"] svg polygon
+#SteamDesktop div[class*="apppartnereventspage_ScrollButton_"] svg polygon
 {
 	fill: var(--headerbar_fg) !important;
 }
 
-[class*="apppartnereventspage_ScrollButton_"][class*="apppartnereventspage_GameArt_"]
+#SteamDesktop div[class*="apppartnereventspage_ScrollButton_"][class*="apppartnereventspage_GameArt_"]
 {
 	height: 40px !important;
 	width: 40px !important;
 }
 
-[class*="partnereventdisplay_EventDetailsBody_"]
+#SteamDesktop div[class*="partnereventdisplay_EventDetailsBody_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
 	font-weight: var(--baseweight) !important;
 }
 
-[class*="partnereventdisplay_EventDetailsBody_"] a:not(.LinkButton)
+#SteamDesktop div[class*="partnereventdisplay_EventDetailsBody_"] a:not(.LinkButton)
 {
 	color: var(--accent) !important;
 	font-family: var(--basefont) !important;
 	font-weight: var(--title_4_weight) !important;
 }
 
-[class*="partnereventdisplay_EventDetailsBody_"] a:not(.LinkButton):hover
+#SteamDesktop div[class*="partnereventdisplay_EventDetailsBody_"] a:not(.LinkButton):hover
 {
 	text-decoration: underline !important;
 }
 
-[class*="partnereventdisplay_EventDetailsBody_"] img,
-[class*="youtubeembed_PreviewYouTubeVideo_"]
+#SteamDesktop div[class*="partnereventdisplay_EventDetailsBody_"] img,
+#SteamDesktop div[class*="youtubeembed_PreviewYouTubeVideo_"]
 {
 	border-radius: var(--card_radius) !important;
 }
 
-[class*="eventbbcodeparser_Header1_"]
+#SteamDesktop div[class*="eventbbcodeparser_Header1_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -410,7 +410,7 @@
 	font-weight: var(--title_1_weight) !important;
 }
 
-[class*="eventbbcodeparser_Header2_"]
+#SteamDesktop div[class*="eventbbcodeparser_Header2_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -418,7 +418,7 @@
 	font-weight: var(--title_2_weight) !important;
 }
 
-[class*="eventbbcodeparser_Header3_"]
+#SteamDesktop div[class*="eventbbcodeparser_Header3_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -426,7 +426,7 @@
 	font-weight: var(--title_3_weight) !important;
 }
 
-[class*="eventbbcodeparser_Header4_"]
+#SteamDesktop div[class*="eventbbcodeparser_Header4_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -434,13 +434,13 @@
 	font-weight: var(--title_4_weight) !important;
 }
 
-[class*="discussionwidget_VoteUpStaticIcon_"],
-[class*="discussionwidget_DiscussionCount_"] > svg
+#SteamDesktop svg[class*="discussionwidget_VoteUpStaticIcon_"],
+#SteamDesktop div[class*="discussionwidget_DiscussionCount_"] > svg
 {
 	fill: var(--accent) !important;
 }
 
-[class*="partnereventshared_Button_"][class*="partnereventshared_Icon_"]
+#SteamDesktop div[class*="partnereventshared_Button_"][class*="partnereventshared_Icon_"]
 {
 	background: var(--button_bg) !important;
 	border-radius: var(--button_radius) !important;
@@ -452,65 +452,65 @@
 	transition: var(--focus_transition) !important;
 }
 
-[class*="partnereventshared_Button_"][class*="partnereventshared_Icon_"]:hover
+#SteamDesktop div[class*="partnereventshared_Button_"][class*="partnereventshared_Icon_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 }
 
-[class*="partnereventshared_Button_"][class*="partnereventshared_Icon_"]:active
+#SteamDesktop div[class*="partnereventshared_Button_"][class*="partnereventshared_Icon_"]:active
 {
 	background: var(--button_active_bg) !important;
 }
 
 /* Post Game Summary */
-[class*="spotlightgameplaysummary_SummaryCarouselContainer_"]
+#SteamDesktop div[class*="spotlightgameplaysummary_SummaryCarouselContainer_"]
 {
 	background: var(--card_bg) !important;
 	border-radius: var(--card_radius) !important;
 }
 
-[class*="spotlightgameplaysummary_SummaryCarouselContainer_"]::after
+#SteamDesktop div[class*="spotlightgameplaysummary_SummaryCarouselContainer_"]::after
 {
 	box-shadow: none !important;
 }
 
 /* Remove Glassy Background */
-[class*="appdetailsoverview_BackdropGlass_"]
+#SteamDesktop div[class*="appdetailsoverview_BackdropGlass_"]
 {
 	background: none !important;
 	border-top: 1px solid var(--border) !important;
 }
 
-[class*="appdetailsplaysection_Glassy_"][class*="appdetailsplaysection_PlayBar_"]
+#SteamDesktop div[class*="appdetailsplaysection_Glassy_"][class*="appdetailsplaysection_PlayBar_"]
 {
 	background: var(--view_bg) !important;
 	border-bottom: 1px solid var(--border) !important;
 }
 
-[class*="appdetailsoverview_Container_"]
+#SteamDesktop div[class*="appdetailsoverview_Container_"]
 {
 	background: var(--bg) !important;
 }
 
 /* Available DLC */
-[class*="appactivitydlc_Contents_"],
-[class*="appactivitydlc_CarouselItem_"] [class*="appactivitydlc_CarouselImage_"]
+#SteamDesktop div[class*="appactivitydlc_Contents_"],
+#SteamDesktop a[class*="appactivitydlc_CarouselItem_"] div[class*="appactivitydlc_CarouselImage_"]
 {
 	box-shadow: none !important;
 }
 
-[class*="appactivitydlc_ViewAll_"]
+#SteamDesktop a[class*="appactivitydlc_ViewAll_"]
 {
 	border-radius: var(--button_radius) !important;
 }
 
-[class*="appactivitydlc_ViewAll_"]:hover
+#SteamDesktop a[class*="appactivitydlc_ViewAll_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	border-radius: var(--button_radius) !important;
 }
 
-[class*="appdetailsdlcsection_StoreHover_"]
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) iframe[class*="appdetailsdlcsection_StoreHover_"]
 {
 	border-radius: var(--card_radius) !important;
 }
@@ -522,8 +522,8 @@
 }
 
 /* Write a Review */
-[class*="writereview_Playtime_"],
-[class*="writereview_ReviewThumbButton_"]
+#SteamDesktop div[class*="writereview_Playtime_"],
+#SteamDesktop button[class*="writereview_ReviewThumbButton_"]
 {
 	color: var(--accent) !important;
 	font-family: var(--basefont) !important;
@@ -531,22 +531,22 @@
 	font-weight: var(--title_4_weight) !important;
 }
 
-[class*="writereview_ThumbIcon_"]
+#SteamDesktop svg[class*="writereview_ThumbIcon_"]
 {
 	fill: var(--accent) !important;
 }
 
-[class*="writereview_ThumbIcon_"][class*="writereview_Up_"]
+#SteamDesktop svg[class*="writereview_ThumbIcon_"][class*="writereview_Up_"]
 {
 	top: -1px !important;
 }
 
-[class*="writereview_ThumbIcon_"][class*="writereview_Down_2DXZF"]
+#SteamDesktop svg[class*="writereview_ThumbIcon_"][class*="writereview_Down_"]
 {
 	bottom: -1px !important;
 }
 
-[class*="writereview_RatingContainer_"] [class*="writereview_RecommendGame_"]
+#SteamDesktop div[class*="writereview_RatingContainer_"] div[class*="writereview_RecommendGame_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -554,8 +554,8 @@
 }
 
 /* Gameplay Summary */
-[class*="spotlightgameplaysummary_EventHeaderBlock_"],
-[class*="spotlightgameplaysummary_GamePlaySummaryHeader_"]
+#SteamDesktop [class*="spotlightgameplaysummary_EventHeaderBlock_"],
+#SteamDesktop [class*="spotlightgameplaysummary_GamePlaySummaryHeader_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -563,13 +563,13 @@
 	font-weight: var(--title_3_weight) !important;
 }
 
-[class*="spotlightgameplaysummary_EventDaySeparator_"]
+#SteamDesktop [class*="spotlightgameplaysummary_EventDaySeparator_"]
 {
 	background-color: var(--dim_label_fg) !important;
 	opacity: 0.55 !important;
 }
 
-[class*="appdetailsachievementssection_Stats_"]
+#SteamDesktop [class*="appdetailsachievementssection_Stats_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
@@ -577,48 +577,48 @@
 }
 
 /* Activity Post */
-[class*="posttextentry_PostTextEntryArea_"],
-[class*="posttextentry_PostTextEntryArea_"]:focus,
-[class*="posttextentry_PostButton_"],
-[class*="posttextentry_EmoticonButton_"]
+#SteamDesktop textarea[class*="posttextentry_PostTextEntryArea_"],
+#SteamDesktop textarea[class*="posttextentry_PostTextEntryArea_"]:focus,
+#SteamDesktop div[class*="posttextentry_PostButton_"],
+#SteamDesktop button[class*="posttextentry_EmoticonButton_"]
 {
 	background: var(--button_bg) !important;
 	border-radius: var(--button_radius) !important;
 	box-shadow: none !important;
 }
 
-[class*="posttextentry_PostButton_"]
+#SteamDesktop div[class*="posttextentry_PostButton_"]
 {
 	font-family: var(--basefont) !important;
 	font-size: var(--button_font_size) !important;
 	font-weight: var(--button_font_weight) !important;
 }
 
-[class*="posttextentry_PostTextEntryArea_"]::placeholder
+#SteamDesktop textarea[class*="posttextentry_PostTextEntryArea_"]::placeholder
 {
 	color: var(--dim_label_fg) !important;
 }
 
-[class*="posttextentry_PostButton_"]:hover,
-[class*="posttextentry_EmoticonButton_"]:hover
+#SteamDesktop div[class*="posttextentry_PostButton_"]:hover,
+#SteamDesktop button[class*="posttextentry_EmoticonButton_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	border-radius: var(--button_radius) !important;
 }
 
 /* Comment and Like Buttons */
-[class*="comment_thread_CanClick_"]:hover
+#SteamDesktop div[class*="comment_thread_CanClick_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	border-radius: var(--button_radius) !important;
 }
 
-[class*="comment_thread_ActivityCommentThread_"]
+#SteamDesktop [class*="comment_thread_ActivityCommentThread_"]
 {
 	background: none !important;
 }
 
-[class*="appdetailssectionheader_LabelText_"]
+#SteamDesktop div[class*="appdetailssectionheader_LabelText_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -626,7 +626,7 @@
 	font-weight: var(--title_3_weight) !important;
 }
 
-[class*="appactivityday_AppActivityDate_"]
+#SteamDesktop div[class*="appactivityday_AppActivityDate_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -635,7 +635,7 @@
 }
 
 /* AppDetails Play Section */
-[class*="appdetailsplaysection_PlayBarLabel_"]
+#SteamDesktop div[class*="appdetailsplaysection_PlayBarLabel_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -643,24 +643,24 @@
 	font-weight: var(--title_3_weight) !important;
 }
 
-[class*="appdetailsplaysection_PlayBarDetailLabel_"]
+#SteamDesktop div[class*="appdetailsplaysection_PlayBarDetailLabel_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
 }
 
-[class*="appdetailsplaysection_PlayBarCloudStatusContainer_"] [class*="appdetailsplaysection_GameStatIconForced_"]
+#SteamDesktop div[class*="appdetailsplaysection_PlayBarCloudStatusContainer_"] div[class*="appdetailsplaysection_GameStatIconForced_"]
 {
 	color: var(--dim_label_fg) !important;
 }
 
-[class*="appdetailsplaysection_PlaytimeIcon_"] > svg > *,
-[class*="appdetailsplaysection_GameStatIcon_"] > svg > *
+#SteamDesktop div[class*="appdetailsplaysection_PlaytimeIcon_"] > svg > *,
+#SteamDesktop div[class*="appdetailsplaysection_GameStatIcon_"] > svg > *
 {
 	stroke: var(--dim_label_fg) !important;
 }
 
-[class*="appdetailsplaysection_PlayBarGameName_"]
+#SteamDesktop span[class*="appdetailsplaysection_PlayBarGameName_"]
 {
 	color: var(--fg) !important;
 	font-family: var(--basefont) !important;
@@ -669,41 +669,37 @@
 }
 
 /* AppDetails Play Section Buttons */
-[class*="appdetailsplaysection_MenuButton_"]
+#SteamDesktop div[class*="appdetailsplaysection_MenuButton_"]
 {
 	background: var(--button_bg) !important;
 	border-radius: var(--button_radius) !important;
 }
 
-[class*="appdetailsplaysection_MenuButton_"]:hover
+#SteamDesktop div[class*="appdetailsplaysection_MenuButton_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	border-radius: var(--button_radius) !important;
 }
 
 /* App Details Link Buttons */
-[class*="appdetailsprimarylinkssection_LinksSectionBody_"]
+#SteamDesktop div[class*="appdetailsprimarylinkssection_LinksSectionBody_"]
 {
 	padding: 0px 10px !important;
 }
 
-[class*="appdetailsprimarylinkssection_Link_"]
+#SteamDesktop div[class*="appdetailsprimarylinkssection_Link_"]
 {
+	border-radius: var(--button_radius) !important;
 	padding: 5px 10px !important;
 }
 
-[class*="appdetailsprimarylinkssection_Link_"]
-{
-	border-radius: var(--button_radius) !important;
-}
-
-[class*="appdetailsprimarylinkssection_Link_"]:hover
+#SteamDesktop div[class*="appdetailsprimarylinkssection_Link_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 }
 
-[class*="appdetailsprimarylinkssection_Text_"],
-[class*="appdetailsprimarylinkssection_Link_"]:hover [class*="appdetailsprimarylinkssection_Text_"]
+#SteamDesktop span[class*="appdetailsprimarylinkssection_Text_"],
+#SteamDesktop div[class*="appdetailsprimarylinkssection_Link_"]:hover span[class*="appdetailsprimarylinkssection_Text_"]
 {
 	color: var(--button_fg) !important;
 	font-family: var(--basefont) !important;
@@ -712,7 +708,7 @@
 }
 
 /* Right Side Buttons */
-[class*="appdetailsbutton_AppDetailsButton_"]
+#SteamDesktop button[class*="appdetailsbutton_AppDetailsButton_"]
 {
 	background: none !important;
 	border-radius: var(--button_radius) !important;
@@ -722,22 +718,22 @@
 	font-weight: var(--button_font_weight) !important;
 }
 
-[class*="appdetailsbutton_AppDetailsButton_"]:hover
+#SteamDesktop button[class*="appdetailsbutton_AppDetailsButton_"]:hover
 {
 	background: var(--button_hover_bg) !important;
 	border-radius: var(--button_radius) !important;
 }
 
-[class*="appdetailsscreenshotssection_InstructionText_"],
-[class*="appdetailsscreenshotssection_NoneTaken_"],
-[class*="appdetailsreviewsection_PlayedForTime_"]
+#SteamDesktop div[class*="appdetailsscreenshotssection_InstructionText_"],
+#SteamDesktop div[class*="appdetailsscreenshotssection_NoneTaken_"],
+#SteamDesktop div[class*="appdetailsreviewsection_PlayedForTime_"]
 {
 	color: var(--dim_label_fg) !important;
 	font-family: var(--basefont) !important;
 	font-weight: var(--baseweight) !important;
 }
 
-[class*="appdetailssection_Body_"] span[style="color: white;"]
+#SteamDesktop div[class*="appdetailssection_Body_"] span[style="color: white;"]
 {
 	color: var(--accent) !important;
 }

--- a/extras/web/full/library.css
+++ b/extras/web/full/library.css
@@ -1,32 +1,28 @@
 /* --- Main Library View --- */
 /* Play Button */
-[class*="appportrait_Play_1"]
-{
-	border-radius: var(--button_radius) !important;
-}
-
-[class*="appportrait_Download_"]
+#SteamDesktop div[class*="appportrait_Play_"],
+#SteamDesktop div[class*="appportrait_Download_"]
 {
 	border-radius: var(--button_radius) !important;
 }
 
 /* Rounded Corners on Game Logos */
-[class*="appportrait_LibraryItemBox_"],
-[class*="libraryhomenewupdates_PartnerEventRowCapsule_MainImageContainer_"],
-[class*="appportraithover_AppPortraitHover_"],
-[class*="appportraithover_CapsuleBackgroundContainer_"]
+#SteamDesktop div[class*="appportrait_LibraryItemBox_"],
+#SteamDesktop div[class*="libraryhomenewupdates_PartnerEventRowCapsule_MainImageContainer_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="appportraithover_AppPortraitHover_"],
+body:not([class*="gamepadui_GamepadUIPopupWindowBody_"]) div[class*="appportraithover_CapsuleBackgroundContainer_"]
 {
 	border-radius: var(--card_radius) !important;
 }
 
-[class*="appportrait_LibraryItemBox_"][class*="appportrait_FeaturedCapsule_"] [class*="libraryassetimage_Image_"]
+#SteamDesktop div[class*="appportrait_LibraryItemBox_"][class*="appportrait_FeaturedCapsule_"] img[class*="libraryassetimage_Image_"]
 {
 	border-bottom-left-radius: 0px !important;
 	border-bottom-right-radius: 0px !important;
 }
 
 /* Game Hours Subscript */
-[class*="appportrait_LibraryItemBoxSubscript_"]
+#SteamDesktop div[class*="appportrait_LibraryItemBoxSubscript_"]
 {
 	background: var(--toast_bg) !important;
 	border-radius: var(--toast_border_radius) !important;
@@ -34,12 +30,12 @@
 }
 
 /* New to Library */
-[class*="appportrait_AppPortraitBannerContainer_"]
+#SteamDesktop [class*="appportrait_AppPortraitBannerContainer_"]
 {
 	top: 1px !important;
 }
 
-[class*="appportrait_AppPortraitBannerContainer_"] [class*="appportrait_AppPortraitBanner_"]
+#SteamDesktop [class*="appportrait_AppPortraitBannerContainer_"] [class*="appportrait_AppPortraitBanner_"]
 {
 	background: var(--accent_bg) !important;
 	border-bottom-left-radius: var(--card_radius) !important;
@@ -47,7 +43,7 @@
 }
 
 /* Update Summary */
-[class*="libraryhomenewupdates_HoversEnabled_"]:hover [class*="libraryhomenewupdates_EventSummaryContainer_"]
+#SteamDesktop div[class*="libraryhomenewupdates_HoversEnabled_"]:hover div[class*="libraryhomenewupdates_EventSummaryContainer_"]
 {
 	border-radius: var(--card_radius);
 }


### PR DESCRIPTION
Decent amount of selector changes, partially to avoid theming Big Picture, partially a general cleanup.

## Big Picture

Steam provides a useful node ID for avoiding this:
```css
#SteamDesktop
```

But as it isn't a top level node, tooltips and other hover elements that like to get injected as a direct child of `body` will bypass this. For these we have to resort to using a `:not()` selector on the body class itself.

```css
body:not([class*="gamepadui_GamepadUIPopupWindowBody_"])
```

## Cleanup

Did a bit of cleanup to avoid straight up using:
```css
[class*="etc_etc"]
```
type selectors. Now most selectors include the tag of the element they're targeting:

 ```css
span[class*="etc_etc"]
```

Which should at least be a slightly less blatant abuse of wildcard selectors. Moving forward we should avoid tagless selectors when possible.
There are a couple stragglers left where I couldn't easily trigger the corresponding elements to show, like with `cloudconflict_`.

Dialog selectors that were too general have been constrained to `.ModalDialogPopup`:

 ```css
.ModalDialogPopup span[class*="etc_etc"]
```