### PR TITLE
Adjust No Rounded Corners

### DIFF
--- a/web/extras/general/no_rounded_corners.css
+++ b/web/extras/general/no_rounded_corners.css
@@ -3,12 +3,12 @@
 /* ------------------------------- */
 :root
 {
-	--button_radius: 0px;
-	--button_pill_radius: 0px;
-	--checkbox_radius: 0px;
-	--card_radius: 0px;
-	--entry_radius: 0px;
-	--menu_radius: 0px;
-	--window_radius: 0px;
-	--popover_radius: 0px;
+	--button_radius: 1px;
+	--button_pill_radius: 1px;
+	--checkbox_radius: 1px;
+	--card_radius: 1px;
+	--entry_radius: 1px;
+	--menu_radius: 1px;
+	--window_radius: 1px;
+	--popover_radius: 1px;
 }

--- a/web/extras/general/no_rounded_corners.css
+++ b/web/extras/general/no_rounded_corners.css
@@ -3,13 +3,13 @@
 /* ------------------------------- */
 :root
 {
-	--button_radius: 1px;
 	--button_pill_radius: 1px;
-	--checkbox_radius: 1px;
+	--button_radius: 1px;
 	--card_radius: 1px;
+	--checkbox_radius: 1px;
 	--entry_radius: 1px;
 	--icon_small_radius: 1px;
 	--menu_radius: 1px;
-	--window_radius: 1px;
 	--popover_radius: 1px;
+	--window_radius: 1px;
 }

--- a/web/extras/general/no_rounded_corners.css
+++ b/web/extras/general/no_rounded_corners.css
@@ -8,6 +8,7 @@
 	--checkbox_radius: 1px;
 	--card_radius: 1px;
 	--entry_radius: 1px;
+	--icon_small_radius: 1px;
 	--menu_radius: 1px;
 	--window_radius: 1px;
 	--popover_radius: 1px;


### PR DESCRIPTION
Applies a 1px radius instead of 0px. Pretty much the same and maintains the not rounded look, just slightly less harsh.
Also adds the new `--icon_small_radius` variable