### PR TITLE
Web Extras: Fix interaction between vanilla_bar and show_arrows

### DIFF
--- a/web/extras/topbar/vanilla_bar.css
+++ b/web/extras/topbar/vanilla_bar.css
@@ -40,3 +40,15 @@
 {
 	background: none !important;
 }
+
+/* Override Show Arrows Web Extra */
+#SteamDesktop .steamdesktop_TopBar_3Z7VQ > div[class*="steamdesktop_SuperNavBar_"] > div[class*="supernav_SuperNav_"] div[class*="supernav_SuperNavMenu_"]:last-child,
+#SteamDesktop .steamdesktop_TopBar_3Z7VQ > div[class*="steamdesktop_SuperNavBar_"] > div[class*="supernav_SuperNav_"] svg[class*="supernav_Arrow_"]:nth-child(2)
+{
+    margin-right: 10px !important;
+}
+
+#SteamDesktop .steamdesktop_TopBar_3Z7VQ > div[class*="steamdesktop_TitleBar_"] > div[class*="steamdesktop_RootMenuBar_"]
+{
+    margin-left: 0px !important;
+}


### PR DESCRIPTION
![image](https://github.com/tkashkin/Adwaita-for-Steam/assets/47908676/d6308c8c-3eed-4431-a343-dc7c084f8119)
The show arrows extra makes some changes designed for the Adwaita style headerbar, which interacts poorly when the vanilla style bar was enabled.
This fixes that interaction, ensuring the vanilla bar extra looks correct even with show arrows enabled.

![image](https://github.com/tkashkin/Adwaita-for-Steam/assets/47908676/455856f7-53c2-49ad-8d5f-6f5865edd672)
