### PR TITLE
Web Base: Fix Top Bar Nav Wrapping

### DIFF
--- a/web/base/top_bar.css
+++ b/web/base/top_bar.css
@@ -114,6 +114,7 @@ body.DesktopUI .steamdesktop_Wrapper_1ENHE
 	text-overflow: ellipsis !important;
 	text-transform: capitalize !important;
 	transition: var(--focus_transition) !important;
+	white-space: nowrap !important;
 }
 
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="supernav_MenuButton_"]:hover


### PR DESCRIPTION
Super Nav seems to have had a change that caused longer items to wrap rather than use text-overflow.
Disables wrapping so we properly hit ellipses.