### PR TITLE
Headerbar: Avatar size/order changes

### DIFF
--- a/adwaita/variants/base/main_window/headerbar/buttons.css
+++ b/adwaita/variants/base/main_window/headerbar/buttons.css
@@ -51,13 +51,25 @@
 }
 
 /* Account Button */
+#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="steamdesktop_TitleBarControls_"] div.Focusable:nth-child(3)
+{
+	order: -99 !important;
+}
+
+#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="steamdesktop_TitleBarControls_"] div.Focusable:nth-child(3) div[class*="titlebarcontrols_AccountMenu_"]:hover,
+#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="steamdesktop_TitleBarControls_"] div.Focusable:nth-child(3) div[class*="titlebarcontrols_AccountMenu_"]:active
+{
+	background: none !important;
+}
+
+#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"]
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"],
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"] div[class*="steamavatar_avatarHolder_"],
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"] div[class*="steamavatar_avatarHolder_"] img.avatar
 {
 	box-sizing: border-box !important;
-	width: 34px !important;
-	height: 34px !important;
+	width: 28px !important;
+	height: 28px !important;
 	padding: 0 !important;
 	border-radius: 50% !important;
 	overflow: hidden !important;
@@ -68,8 +80,8 @@
 
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"] div[class*="steamavatar_avatarHolder_"] img.avatar
 {
-	width: 32px !important;
-	height: 32px !important;
+	width: 26px !important;
+	height: 26px !important;
 	padding: 0 !important;
 	margin: 0 !important;
 }
@@ -79,6 +91,7 @@
 	border-radius: 50% !important;
 	border: 2px var(--profile_offline) solid !important;
 	transition: border-color 0.25s;
+	margin-left: 1px !important;
 }
 
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"] div[class*="steamavatar_avatarHolder_"].online

--- a/adwaita/variants/base/main_window/headerbar/buttons.css
+++ b/adwaita/variants/base/main_window/headerbar/buttons.css
@@ -62,14 +62,13 @@
 	background: none !important;
 }
 
-#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"]
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"],
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"] div[class*="steamavatar_avatarHolder_"],
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"] div[class*="steamavatar_avatarHolder_"] img.avatar
 {
 	box-sizing: border-box !important;
-	width: 28px !important;
-	height: 28px !important;
+	width: 30px !important;
+	height: 30px !important;
 	padding: 0 !important;
 	border-radius: 50% !important;
 	overflow: hidden !important;
@@ -80,8 +79,8 @@
 
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"] div[class*="steamavatar_avatarHolder_"] img.avatar
 {
-	width: 26px !important;
-	height: 26px !important;
+	width: 28px !important;
+	height: 28px !important;
 	padding: 0 !important;
 	margin: 0 !important;
 }
@@ -91,7 +90,7 @@
 	border-radius: 50% !important;
 	border: 2px var(--profile_offline) solid !important;
 	transition: border-color 0.25s;
-	margin-left: 1px !important;
+	margin: 0 auto !important;
 }
 
 #SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="titlebarcontrols_AccountMenu_"] div[class*="steamavatar_avatarHolder_"].online

--- a/adwaita/variants/base/main_window/headerbar/buttons.css
+++ b/adwaita/variants/base/main_window/headerbar/buttons.css
@@ -51,13 +51,13 @@
 }
 
 /* Account Button */
-#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="steamdesktop_TitleBarControls_"] div.Focusable:nth-child(3)
+#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="steamdesktop_TitleBarControls_"]
 {
-	order: -99 !important;
+	flex-direction: row-reverse !important;
 }
 
-#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="steamdesktop_TitleBarControls_"] div.Focusable:nth-child(3) div[class*="titlebarcontrols_AccountMenu_"]:hover,
-#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="steamdesktop_TitleBarControls_"] div.Focusable:nth-child(3) div[class*="titlebarcontrols_AccountMenu_"]:active
+#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="steamdesktop_TitleBarControls_"] div[class*="titlebarcontrols_AccountMenu_"]:hover,
+#SteamDesktop .steamdesktop_TopBar_3Z7VQ div[class*="steamdesktop_TitleBarControls_"] div[class*="titlebarcontrols_AccountMenu_"]:active
 {
 	background: none !important;
 }


### PR DESCRIPTION
Reorders/Resizes the Avatar button so that it is more in line with the rest of the headerbar. Before it was a bit oversized, and was cutting between the notification button and similar button elements.

This does involve using:

```css
div.Focusable:nth-child(3)
```

Which is not ideal, but probably shouldn't be an issue unless the layout changes. 

## Before

![ss-2023-07-28_22:38:35](https://github.com/tkashkin/Adwaita-for-Steam/assets/47908676/9a17d328-07c3-47dc-a56e-38741bda7d3c)

## After

![ss-2023-07-28_22:39:20](https://github.com/tkashkin/Adwaita-for-Steam/assets/47908676/52846ca8-4f1a-4bd8-9e0a-627ee00cb893)