### PR TITLE
Add CSS Loader config to repository

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,133 @@
+{
+    "name": "Adwaita For Steam",
+    "author": "tkashkin",
+    "version": "v1.12",
+    "manifest_version": 8,
+    "description": "A skin to make Steam look more like a native GNOME app",
+    "target": "Desktop",
+    "tabs": {
+        "all": ["desktop", "desktopchat", "desktopcontextmenu", "desktopoverlay"]
+    },
+    "inject": {
+        "adwaita/variants/base/_root.css": ["all"],
+        "adwaita/variants/base/_fonts.css": ["all"],
+        "adwaita/variants/base/_localization.css": ["all"],
+        "adwaita/variants/base/scrollbars.css": ["all"],
+        "adwaita/variants/base/main_window/headerbar/headerbar.css": ["all"],
+        "adwaita/variants/base/main_window/headerbar/buttons.css": ["all"],
+        "adwaita/variants/base/main_window/headerbar/navigation.css": ["all"],
+        "adwaita/variants/base/main_window/headerbar/menu.css": ["all"],
+        "adwaita/variants/base/library.css": ["all"],
+        "adwaita/variants/full/library.css": ["all"],
+        "adwaita/variants/base/game_details.css": ["all"],
+        "adwaita/variants/full/game_details.css": ["all"],
+        "adwaita/variants/base/downloads.css": ["all"],
+        "adwaita/variants/full/downloads.css": ["all"],
+        "adwaita/variants/base/collections.css": ["all"],
+        "adwaita/variants/base/dialogs/_dialogs.css": ["all"],
+        "adwaita/variants/base/dialogs/launch_options.css": ["all"],
+        "adwaita/variants/base/dialogs/login.css": ["all"],
+        "adwaita/variants/full/dialogs/_dialogs.css": ["all"],
+        "adwaita/variants/full/dialogs/about_steam.css": ["all"],
+        "adwaita/variants/full/dialogs/add_game.css": ["all"],
+        "adwaita/variants/full/dialogs/app_properties.css": ["all"],
+        "adwaita/variants/full/dialogs/content_management.css": ["all"],
+        "adwaita/variants/full/dialogs/install_game.css": ["all"],
+        "adwaita/variants/full/dialogs/paged_settings.css": ["all"],
+        "adwaita/variants/full/dialogs/product_activation.css": ["all"],
+        "adwaita/variants/full/dialogs/recent_players.css": ["all"],
+        "adwaita/variants/full/dialogs/screenshots.css": ["all"],
+        "adwaita/variants/full/dialogs/server_browser.css": ["all"],
+        "adwaita/variants/full/dialogs/steam_settings.css": ["all"],
+        "adwaita/variants/full/dialogs/system_information.css": ["all"],
+        "adwaita/variants/full/dialogs/uninstall.css": ["all"],
+        "adwaita/variants/full/dialogs/update_news.css": ["all"],
+        "adwaita/variants/full/dialogs/whats_new.css": ["all"],
+        "adwaita/variants/base/game_overlay.css": ["all"],
+        "adwaita/variants/base/notifications.css": ["all"],
+        "adwaita/variants/full/chat.css": ["all"]
+    },
+    "patches": {
+        "Color Theme": {
+            "type":  "dropdown",
+            "values": {
+                "adwaita": { "adwaita/colorthemes/adwaita/adwaita.css": ["all"] },
+                "breeze": { "adwaita/colorthemes/breeze/breeze.css": ["all"] },
+                "canta": { "adwaita/colorthemes/canta/canta.css": ["all"] },
+                "catppuccin-frappe": { "adwaita/colorthemes/catppuccin-frappe/catppuccin-frappe.css": ["all"] },
+                "catppuccin-macchiato": { "adwaita/colorthemes/catppuccin-macchiato/catppuccin-macchiato.css": ["all"] },
+                "catppuccin-mocha": { "adwaita/colorthemes/catppuccin-mocha/catppuccin-mocha.css": ["all"] },
+                "dracula": { "adwaita/colorthemes/dracula/dracula.css": ["all"] },
+                "gruvbox": { "adwaita/colorthemes/gruvbox/gruvbox.css": ["all"] },
+                "kate": { "adwaita/colorthemes/kate/kate.css": ["all"] },
+                "metro": { "adwaita/colorthemes/metro/metro.css": ["all"] },
+                "nord": { "adwaita/colorthemes/nord/nord.css": ["all"] },
+                "one-pro": { "adwaita/colorthemes/one-pro/one-pro.css": ["all"] },
+                "pop": { "adwaita/colorthemes/pop/pop.css": ["all"] },
+                "tokyo-night": { "adwaita/colorthemes/tokyo-night/tokyo-night.css": ["all"] },
+                "tomorrow-night": { "adwaita/colorthemes/tomorrow-night/tomorrow-night.css": ["all"] },
+                "yaru": { "adwaita/colorthemes/yaru/yaru.css": ["all"] }
+            }
+        },
+        "Rounded Corners": {
+            "type": "checkbox",
+            "values": {
+                "Yes": {},
+                "No": {
+                    "adwaita/extras/general/no_rounded_corners.css": ["all"]
+                }
+            }
+        },
+        "Show What's New": {
+            "type": "checkbox",
+            "values": {
+                "Yes": {},
+                "No": {
+                    "adwaita/extras/library/hide_whats_new.css": ["all"]
+                }
+            }
+        },
+        "Show Library Sidebar On Hover": {
+            "type": "checkbox",
+            "values": {
+                "No": {},
+                "Yes": {
+                    "adwaita/extras/library/sidebar_hover.css": ["all"]
+                }
+            }
+        },
+        "Login QR": {
+            "type": "dropdown",
+            "values": {
+                "Show": {},
+                "Show on Hover": {
+                    "adwaita/extras/login/hover_qr.css": ["all"]
+                },
+                "Hide": {
+                    "adwaita/extras/login/hide_qr.css": ["all"]
+                }
+            }
+        },
+        "Window Controls": {
+            "type": "dropdown",
+            "values": {
+                "Default": {},
+                "Dots": {
+                    "adwaita/extras/windowcontrols/dots.css": ["all"]
+                },
+                "Hide Close": {
+                    "adwaita/extras/windowcontrols/hide-close.css": ["all"]
+                },
+                "Left All": {
+                    "adwaita/extras/windowcontrols/left-all.css": ["all"]
+                },
+                "Left": {
+                    "adwaita/extras/windowcontrols/left.css": ["all"]
+                },
+                "Right All": {
+                    "adwaita/extras/windowcontrols/right-all.css": ["all"]
+                }
+            }
+        }
+    }
+}

--- a/theme.json
+++ b/theme.json
@@ -6,7 +6,7 @@
     "description": "A skin to make Steam look more like a native GNOME app",
     "target": "Desktop",
     "tabs": {
-        "all": ["desktop", "desktopchat", "desktopcontextmenu", "desktopoverlay"]
+        "all": ["Steam|SteamLibraryWindow", "desktopchat", "desktopcontextmenu", "desktopoverlay"]
     },
     "inject": {
         "adwaita/variants/base/_root.css": ["all"],


### PR DESCRIPTION
This allows the theme to be loaded through CSS Loader. Loading through CSS Loader also resolves the Steam Big Picture injection issue.
![image](https://github.com/tkashkin/Adwaita-for-Steam/assets/38142618/cb82dc24-52a2-42c1-b15e-7c670b3fa9c7)
