### PR TITLE
Add option to use custom.css on CSS Loader

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -130,6 +130,15 @@
                     "adwaita/extras/windowcontrols/right-all.css": ["all"]
                 }
             }
+        },
+        "Enable Custom CSS": {
+            "type": "dropdown",
+            "values": {
+                "No": {},
+                "Yes": {
+                    "custom/custom.css": ["all"]
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
I'm pretty sure that there isn't a way to use custom css when under CSS Loader, so I added one to my local copy.