### PR TITLE
Fix: Do not overwrite args.target on Windows if value is set

### DIFF
--- a/install.py
+++ b/install.py
@@ -263,12 +263,15 @@ if __name__ == "__main__":
 	parser.add_argument("-d", "--dev", action = "store_true", help = "Dev Mode")
 	parser.add_argument("-e", "--extras", nargs = "+", action = "extend", help = "Enable one or multiple theme extras")
 	parser.add_argument("-l", "--list-options", action = "store_true", help = "List available themes & extras and exit")
-	parser.add_argument("-t", "--target", nargs = "+", action = "extend", default = ["normal", "flatpak"], help = "Install targets: 'normal', 'flatpak', custom paths")
+	parser.add_argument("-t", "--target", nargs = "+", action = "extend", help = "Install targets: 'normal', 'flatpak', custom paths")
 	parser.add_argument("-u", "--uninstall", action = "store_true", help = "Uninstall theme")
 	args = parser.parse_args()
 
-	if WINDOWS_RUN:
-		args.target = ["windows"]
+	if args.target is None:
+		args.target = ["normal", "flatpak"]
+
+		if WINDOWS_RUN:
+			args.target = ["windows"]			
 
 	if args.list_options:
 		list_options("color themes", find_color_themes(), ".css", colorthemedir, "color-theme")


### PR DESCRIPTION
### Short Description
Fixes the unexpected behaviour on Windows that causes the `args.target` always to be overwritten, effectively disabling the `--target` argument on Windows and requiring manual edits to the constants to change the target destination path.

This PR also changes the default behaviour on non-Windows systems, so that default values are no longer being strictly enforced when additional or explicit parameter values have been given for the `--target` argument.

### How To Reproduce (Current Codebase)
1. Call `install.py` with the `--target` argument on Windows and supply a custom path.
2. Output the contents of `args.target`.
3. The supplied custom path was lost, defaulting to the value `windows`.

### How To Test (Pull Request)
1. Same steps as for the reproduction.
2. On non-Windows systems:
2.1. Do not specify the `--target` argument.
2.2. This will default to the values `normal` and `flatpak`.
2.3. Specify values for the `--target` argument (i.e. `--target "flatpak" "/tmp/steam"`).
2.4. Check `args.target`, only the specified values are present.
