### PR TITLE
Fix some menu item text wrapping.

### DIFF
--- a/adwaita/css/widgets/popups.css
+++ b/adwaita/css/widgets/popups.css
@@ -55,7 +55,7 @@ html.client_chat_frame
 
 			& > div
 			{
-				display: inline-block !important;
+				display: inline-flex !important;
 				overflow: hidden !important;
 				white-space: nowrap !important;
 				text-overflow: ellipsis !important;


### PR DESCRIPTION
||Before|After|
|-|-|-|
|Friends menu|![Friends menu before](https://github.com/user-attachments/assets/b6687988-5f15-40ce-8e8c-0b77491fa3be)|![Friends menu after](https://github.com/user-attachments/assets/16a596b0-faf7-4c8e-80bd-05147996f435)|
|Account menu|![Account menu before](https://github.com/user-attachments/assets/06ddf299-87d6-44bc-ba45-7eeeee681905)|![Account menu after](https://github.com/user-attachments/assets/cf062602-5ac8-4478-ae9c-01b4890ae662)|
