### PR TITLE
Snap target

### DIFF
--- a/install.py
+++ b/install.py
@@ -45,6 +45,7 @@ CUSTOM_DIR = "custom"
 EXTRAS_DIR = f"{ADWAITA_DIR}/extras"
 
 TARGET_NORMAL = "~/.steam/steam"
+TARGET_SNAP = "~/snap/steam/common/.steam/steam"
 TARGET_FLATPAK = "~/.var/app/com.valvesoftware.Steam/.steam/steam"
 TARGET_WINDOWS = "C:\\Program Files (x86)\\Steam"
 TARGET_MACOS = "~/Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS"
@@ -331,6 +332,8 @@ if __name__ == "__main__":
 	for t in args.target:
 		if t == "normal":
 			targets.add(Path(TARGET_NORMAL).expanduser().resolve())
+		elif t == "snap":
+			targets.add(Path(TARGET_SNAP).expanduser().resolve())
 		elif t == "flatpak":
 			targets.add(Path(TARGET_FLATPAK).expanduser().resolve())
 		elif t == "windows":

--- a/scripts/update_classes.sh
+++ b/scripts/update_classes.sh
@@ -35,9 +35,11 @@ EXTRAS_DIR="extras"
 FULL_DIR="full"
 
 STEAM="$HOME/.steam/steam"
+STEAM_SNAP="$HOME/snap/steam/common/.steam/steam"
 STEAM_FLATPAK="$HOME/.var/app/com.valvesoftware.Steam/.steam/steam"
 
 STEAM_CSS="$STEAM/steamui/css"
+STEAM_CSS_SNAP="$STEAM_SNAP/steamui/css"
 STEAM_CSS_FLATPAK="$STEAM_FLATPAK/steamui/css"
 
 # COLORS
@@ -139,6 +141,8 @@ function dep_check {
 
 if [[ -d "$STEAM_CSS_FLATPAK" ]]; then
 	CSS_DIR="$STEAM_CSS_FLATPAK"
+elif [[ -d "$STEAM_CSS_SNAP" ]]; then
+	CSS_DIR="$STEAM_CSS_SNAP"
 elif [[ -d "$STEAM_CSS" ]]; then
 	CSS_DIR="$STEAM_CSS"
 else


### PR DESCRIPTION
This adds "snap" to the target arguments, which looks for a directory `~/snap/steam/common/.steam/steam` and use it to load the theme.

Usage example

```sh
./install.py -c rose-pine -e login/hide_qr -e library/hide_whats_new -tsnap
```

I've only tested this on my system

```
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04.2 LTS
Release:	24.04
Codename:	noble
```

Let me know if there are any issues with your systems that I can try fix, or feel free to fix them yourself.