### PR TITLE
extras: add library/uncrop-covers-in-details

### DIFF
--- a/adwaita/extras/library/uncrop-covers-in-details.css
+++ b/adwaita/extras/library/uncrop-covers-in-details.css
@@ -1,0 +1,19 @@
+/* Don't crop game covers on game details pages */
+
+body.DesktopUI div._2iE-78WxX2Pj4GHbq7YJiA
+div._1_cYNJSvS6IXs9vLTEYjy5 /* Content */
+div._25oBZpa3dUcMw8QAsa2u67 /* Game info */
+div._2jPMy2QZr8bWi6yrk5ZzHA
+div._37mmOlZM_8n5yJAG5CHiW7
+div._1Id6ZFEUVa5PKEMIvSg4nE /* Grid image */
+{
+	/* Identical to the &:hover block in library/details/header.css */
+
+	height: 96px !important;
+	translate: 0 -16px !important;
+
+	div._1R9r2OBCxAmtuUVrgBEUBw
+	{
+		translate: 0 0 !important;
+	}
+}

--- a/skin.json
+++ b/skin.json
@@ -180,6 +180,16 @@
 				"yes": { "TargetCss": { "affects": [".*"], "src": "adwaita/extras/library/sidebar-hover.css" } }
 			}
 		},
+		"Square icons in game details": {
+			"description": "Crops game covers on game detail pages to be square",
+			"tab": "Extras",
+			"section": "Library",
+			"default": "yes",
+			"values": {
+				"no": { "TargetCss": { "affects": [".*"], "src": "adwaita/extras/library/uncrop-covers-in-details.css" } },
+				"yes": {}
+			}
+		},
 		"Login QR code": {
 			"description": "Changes visibility of QR code in the Login window",
 			"tab": "Extras",

--- a/theme.json
+++ b/theme.json
@@ -133,6 +133,13 @@
 				"Yes": { "adwaita/extras/library/sidebar-hover.css": ["desktop"] }
 			}
 		},
+		"Square icons in game details": {
+			"type": "checkbox",
+			"values": {
+				"Yes": {},
+				"No": { "adwaita/extras/library/uncrop-covers-in-details.css": ["desktop"] }
+			}
+		},
 		"Login QR code": {
 			"type": "dropdown",
 			"values": {


### PR DESCRIPTION
This simply removes the cropping of cover art on the games details page. Some cover art looks okay when cropped into a square, but many look quite odd, and I would rather see them in full.

Hovering it now does nothing. The zoom functionality has not changed. The fallback icon used while the cover art loads remains a square.

<img width="437" height="128" alt="Game title next to uncropped cover art" src="https://github.com/user-attachments/assets/fd19021e-64ba-4d7f-9416-7af28100107b" />

I couldn't find any contributing documentation, hopefully I did this correctly!